### PR TITLE
enable actinia to connect to a password protected redis db

### DIFF
--- a/scripts/actinia-server
+++ b/scripts/actinia-server
@@ -67,8 +67,14 @@ def main():
     create_endpoints()
 
     # Connect the redis interfaces
-    connect(global_config.REDIS_SERVER_URL,
-            global_config.REDIS_SERVER_PORT)
+    redis_args = (global_config.REDIS_SERVER_URL,
+                  global_config.REDIS_SERVER_PORT)
+    if global_config.REDIS_SERVER_PW and global_config.REDIS_SERVER_PW is not None:
+        redis_args = (*redis_args, global_config.REDIS_SERVER_PW)
+
+    connect(*redis_args)
+    del redis_args
+
 
     # Create the process queue
     create_process_queue(global_config)

--- a/scripts/actinia-user
+++ b/scripts/actinia-user
@@ -69,7 +69,7 @@ def set_user_credentials(user, args, method):
     """Set the user credentials
 
     Args:
-        user (graas_api.resources.common.user.ActiniaUser()): The user object
+        user (actinia.resources.common.user.ActiniaUser()): The user object
         args: The command line arguments
         method (str): "create", "update", "update_add",
                       "update_rm", "update_rm_location"
@@ -132,7 +132,7 @@ def set_user_credentials(user, args, method):
 def main():
     """User management
     """
-    parser = argparse.ArgumentParser(description='Manage GRaaS users in the Redis database.',
+    parser = argparse.ArgumentParser(description='Manage actinia users in the Redis database.',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument("action", type=str, default="create",
@@ -150,9 +150,11 @@ def main():
                              " * pwcheck: Check the password of the user"
                         )
     parser.add_argument("-s", "--server", type=str, required=False,
-                        help="The host name of the redis server, default is the value from the GRaaS config file")
+                        help="The host name of the redis server, default is the value from the actinia config file")
     parser.add_argument("-p", "--port", type=int, required=False,
-                        help="The port of the redis server, default is the value from the GRaaS config file")
+                        help="The port of the redis server, default is the value from the actinia config file")
+    parser.add_argument("-a", "--redis_password", type=str, required=False,
+                        help="The password of the redis server, default is the value from the actinia config file or None")
     parser.add_argument("-u", "--user_id", type=str, required=False,
                         help="The user name")
     parser.add_argument("-g", "--user_group", type=str, required=False,
@@ -183,13 +185,18 @@ def main():
 
     server = conf.REDIS_SERVER_URL
     port = conf.REDIS_SERVER_PORT
+    if conf.REDIS_SERVER_PW:
+        redis_password = conf.REDIS_SERVER_PW
+    else:
+        redis_password = None
 
     if args.server:
         server = args.server
     if args.port:
         port = args.port
-
-    redis_user_interface.connect(host=server, port=port)
+    if args.redis_password:
+        redis_password = args.redis_password
+    redis_user_interface.connect(host=server, port=port, password=redis_password)
 
     ######################### CREATE ############################
     if args.action == "create":

--- a/src/actinia_core/main.py
+++ b/src/actinia_core/main.py
@@ -55,8 +55,12 @@ create_endpoints()
 #    return response
 
 # Connect the redis interfaces
-connect(global_config.REDIS_SERVER_URL,
-        global_config.REDIS_SERVER_PORT)
+redis_args = (global_config.REDIS_SERVER_URL, global_config.REDIS_SERVER_PORT)
+if global_config.REDIS_SERVER_PW and global_config.REDIS_SERVER_PW is not None:
+    redis_args = (*redis_args, global_config.REDIS_SERVER_PW)
+
+connect(*redis_args)
+del redis_args
 
 # Create the process queue
 create_process_queue(global_config)

--- a/src/actinia_core/resources/common/config.py
+++ b/src/actinia_core/resources/common/config.py
@@ -107,6 +107,7 @@ class Configuration(object):
         # REDIS
         self.REDIS_SERVER_URL = "127.0.0.1"       # The hostname of the redis server
         self.REDIS_SERVER_PORT = 6379             # The port of the redis server
+        self.REDIS_SERVER_PW = None             # The password of the redis server
         self.REDIS_RESOURCE_EXPIRE_TIME = 864000  # Default expire time is 10 days for resource logs,
         #                                           that are used for calculating the price of resource usage
         self.REDIS_QUEUE_SERVER_URL = "127.0.0.1" # The hostname of the redis work queue server
@@ -200,6 +201,7 @@ class Configuration(object):
         config.add_section('REDIS')
         config.set('REDIS', 'REDIS_SERVER_URL', self.REDIS_SERVER_URL)
         config.set('REDIS', 'REDIS_SERVER_PORT', str(self.REDIS_SERVER_PORT))
+        config.set('REDIS', 'REDIS_SERVER_PW', str(self.REDIS_SERVER_PW))
         config.set('REDIS', 'REDIS_RESOURCE_EXPIRE_TIME', str(self.REDIS_RESOURCE_EXPIRE_TIME))
         config.set('REDIS', 'REDIS_QUEUE_SERVER_URL', self.REDIS_QUEUE_SERVER_URL)
         config.set('REDIS', 'REDIS_QUEUE_SERVER_PORT', str(self.REDIS_QUEUE_SERVER_PORT))
@@ -304,6 +306,8 @@ class Configuration(object):
                     self.REDIS_SERVER_URL = config.get("REDIS", "REDIS_SERVER_URL")
                 if config.has_option("REDIS", "REDIS_SERVER_PORT"):
                     self.REDIS_SERVER_PORT = config.getint("REDIS", "REDIS_SERVER_PORT")
+                if config.has_option("REDIS", "REDIS_SERVER_PW"):
+                    self.REDIS_SERVER_PW = config.get("REDIS", "REDIS_SERVER_PW")
                 if config.has_option("REDIS", "REDIS_RESOURCE_EXPIRE_TIME"):
                     self.REDIS_RESOURCE_EXPIRE_TIME = config.getint("REDIS", "REDIS_RESOURCE_EXPIRE_TIME")
                 if config.has_option("REDIS", "REDIS_QUEUE_SERVER_URL"):

--- a/src/actinia_core/resources/common/process_queue.py
+++ b/src/actinia_core/resources/common/process_queue.py
@@ -388,9 +388,15 @@ def start_process_queue_manager(config, queue, use_logger):
     except:
         pass
     # We need the resource logger to send updates to the resource database
-    resource_logger = ResourceLogger(host=config.REDIS_SERVER_URL,
-                                     port=config.REDIS_SERVER_PORT,
+    kwargs = dict()
+    kwargs['host'] = config.REDIS_SERVER_URL
+    kwargs['port'] = config.REDIS_SERVER_PORT
+    if config.REDIS_SERVER_PW and config.REDIS_SERVER_PW is not None:
+        kwargs['password'] = config.REDIS_SERVER_PW
+    resource_logger = ResourceLogger(**kwargs,
                                      fluent_sender=fluent_sender)
+    del kwargs
+
     count = 0
     try:
         while True:

--- a/src/actinia_core/resources/common/redis_base.py
+++ b/src/actinia_core/resources/common/redis_base.py
@@ -43,16 +43,27 @@ class RedisBaseInterface(object):
         self.connection_pool = None
         self.redis_server = None
 
-    def connect(self, host="localhost", port=6379):
+    def connect(self, host="localhost", port=6379, password=None):
         """Connect to a specific redis server
 
         Args:
             host (str): The host name or IP address
             port (int): The port
+            password (str): The password
 
         """
-        self.connection_pool = redis.ConnectionPool(host=host, port=port)
+        kwargs = dict()
+        kwargs['host'] = host
+        kwargs['port'] = port
+        if password and password is not None:
+            kwargs['password'] = password
+        self.connection_pool = redis.ConnectionPool(**kwargs)
+        del kwargs
         self.redis_server = redis.StrictRedis(connection_pool=self.connection_pool)
+        try:
+            self.redis_server.ping()
+        except redis.exceptions.ResponseError as e:
+            print('ERROR: Could not connect to redis with ' + host, port, password, str(e))
 
     def disconnect(self):
         self.connection_pool.disconnect()

--- a/src/actinia_core/resources/common/redis_interface.py
+++ b/src/actinia_core/resources/common/redis_interface.py
@@ -135,7 +135,7 @@ def enqueue_job_old(timeout, func, *args):
     return current_queue
 
 
-def connect(host, port):
+def connect(host, port, pw=None):
     """Connect all required redis interfaces that should be used
        in the main server process.
 
@@ -145,10 +145,11 @@ def connect(host, port):
     Args:
         host (str): The hostname of the redis server
         port (str): The port of the redis server
+        pw (str): The password of the redis server
 
     """
-    redis_user_interface.connect(host, port)
-    redis_api_log_interface.connect(host, port)
+    redis_user_interface.connect(host, port, pw)
+    redis_api_log_interface.connect(host, port, pw)
 
 
 def disconnect():

--- a/src/actinia_core/resources/common/redis_lock.py
+++ b/src/actinia_core/resources/common/redis_lock.py
@@ -89,15 +89,22 @@ class RedisLockingInterface(object):
         self.call_extend_resource_lock = None
         self.call_unlock_resource = None
 
-    def connect(self, host, port):
+    def connect(self, host, port, password=None):
         """Connect to a specific redis server
 
         Args:
             host (str): The host name or IP address
             port (int): The port
+            password (str): The password
 
         """
-        self.connection_pool = redis.ConnectionPool(host=host, port=port)
+        kwargs = dict()
+        kwargs['host'] = host
+        kwargs['port'] = port
+        if password and password is not None:
+            kwargs['password'] = password
+        self.connection_pool = redis.ConnectionPool(**kwargs)
+        del kwargs
         self.redis_server = redis.StrictRedis(connection_pool=self.connection_pool)
 
         # Register the resource lock scripts in Redis

--- a/src/actinia_core/resources/common/resources_logger.py
+++ b/src/actinia_core/resources/common/resources_logger.py
@@ -48,11 +48,15 @@ class ResourceLogger(RedisFluentLoggerBase):
     """Write, update, receive and delete entries in the resource database
     """
 
-    def __init__(self, host, port, config=None, user_id=None, fluent_sender=None):
+    def __init__(self, host, port, password=None, config=None, user_id=None, fluent_sender=None):
         RedisFluentLoggerBase.__init__(self, config=config, user_id=user_id, fluent_sender=fluent_sender)
         # Connect to a redis database
         self.db = RedisResourceInterface()
-        self.db.connect(host, port)
+        redis_args = (host, port)
+        if password is not None:
+            redis_args = (*redis_args, password)
+        self.db.connect(*redis_args)
+        del redis_args
 
     @staticmethod
     def _generate_db_resource_id(user_id, resource_id):

--- a/src/actinia_core/resources/ephemeral_processing.py
+++ b/src/actinia_core/resources/ephemeral_processing.py
@@ -581,14 +581,19 @@ class EphemeralProcessing(object):
             fluent_sender = sender.FluentSender('actinia_core_logger',
                                                 host=self.config.LOG_FLUENT_HOST,
                                                 port=self.config.LOG_FLUENT_PORT)
+        kwargs = dict()
+        kwargs['host'] = self.config.REDIS_SERVER_URL
+        kwargs['port'] = self.config.REDIS_SERVER_PORT
+        if self.config.REDIS_SERVER_PW and self.config.REDIS_SERVER_PW is not None:
+            kwargs['password'] = self.config.REDIS_SERVER_PW
+        self.resource_logger = ResourceLogger(**kwargs,
+                                              fluent_sender=fluent_sender)
 
-        self.resource_logger = ResourceLogger(host=self.config.REDIS_SERVER_URL,
-                                              port=self.config.REDIS_SERVER_PORT, fluent_sender=fluent_sender)
         self.message_logger = MessageLogger(config=self.config, user_id=self.user_id, fluent_sender=fluent_sender)
 
         self.lock_interface = RedisLockingInterface()
-        self.lock_interface.connect(host=self.config.REDIS_SERVER_URL,
-                                    port=self.config.REDIS_SERVER_PORT)
+        self.lock_interface.connect(**kwargs)
+        del kwargs
         self.process_time_limit = int(self.user_credentials["permissions"]["process_time_limit"])
 
         # Check and create all required paths to global, user and temporary locations

--- a/src/actinia_core/resources/resource_base.py
+++ b/src/actinia_core/resources/resource_base.py
@@ -90,8 +90,14 @@ class ResourceBase(Resource):
         self.orig_time = time.time()
         self.orig_datetime = str(datetime.now())
 
-        self.resource_logger = ResourceLogger(host=global_config.REDIS_SERVER_URL,
-                                              port=global_config.REDIS_SERVER_PORT)
+        kwargs = dict()
+        kwargs['host'] = global_config.REDIS_SERVER_URL
+        kwargs['port'] = global_config.REDIS_SERVER_PORT
+        if global_config.REDIS_SERVER_PW and global_config.REDIS_SERVER_PW is not None:
+            kwargs['password'] = global_config.REDIS_SERVER_PW
+        self.resource_logger = ResourceLogger(**kwargs)
+        del kwargs
+
         self.message_logger = MessageLogger()
 
         self.grass_data_base = global_config.GRASS_DATABASE

--- a/src/actinia_core/resources/resource_management.py
+++ b/src/actinia_core/resources/resource_management.py
@@ -57,8 +57,13 @@ class ResourceManagerBase(Resource):
         # Configuration
         Resource.__init__(self)
 
-        self.resource_logger = ResourceLogger(host=global_config.REDIS_SERVER_URL,
-                                              port=global_config.REDIS_SERVER_PORT)
+        kwargs = dict()
+        kwargs['host'] = global_config.REDIS_SERVER_URL
+        kwargs['port'] = global_config.REDIS_SERVER_PORT
+        if global_config.REDIS_SERVER_PW and global_config.REDIS_SERVER_PW is not None:
+            kwargs['password'] = global_config.REDIS_SERVER_PW
+        self.resource_logger = ResourceLogger(**kwargs)
+        del kwargs
 
         # Store the user id, user group and all credentials of the current user
 

--- a/src/actinia_core/testsuite.py
+++ b/src/actinia_core/testsuite.py
@@ -161,8 +161,11 @@ class ActiniaTestCaseBase(unittest.TestCase):
             #                                  global_config.NUMBER_OF_WORKERS)
 
         # Start the redis interface
-        redis_interface.connect(global_config.REDIS_SERVER_URL,
-                                global_config.REDIS_SERVER_PORT)
+        redis_args = (global_config.REDIS_SERVER_URL, global_config.REDIS_SERVER_PORT)
+        if global_config.REDIS_SERVER_PW and global_config.REDIS_SERVER_PW is not None:
+            redis_args = (*redis_args, global_config.REDIS_SERVER_PW)
+
+        redis_interface.connect(*redis_args)
 
         # Process queue
         create_process_queue(config=global_config)

--- a/tests/test_common_base.py
+++ b/tests/test_common_base.py
@@ -103,8 +103,11 @@ class CommonTestCaseBase(unittest.TestCase):
             global_config.REDIS_SERVER_URL = "localhost"
             global_config.REDIS_SERVER_PORT = 7000
 
-        redis_interface.connect(global_config.REDIS_SERVER_URL,
-                                global_config.REDIS_SERVER_PORT)
+        args = (global_config.REDIS_SERVER_URL, global_config.REDIS_SERVER_PORT)
+        if global_config.REDIS_SERVER_PW and global_config.REDIS_SERVER_PW is not None:
+            args = (*args, global_config.REDIS_SERVER_PW)
+
+        redis_interface.connect(*args)
 
     @classmethod
     def tearDownClass(cls):
@@ -117,4 +120,3 @@ class CommonTestCaseBase(unittest.TestCase):
 
     def tearDown(self):
         self.app_context.pop()
-

--- a/tests/test_resource_logging.py
+++ b/tests/test_resource_logging.py
@@ -54,8 +54,13 @@ class ResourceLoggingTestCase(ActiniaResourceTestCaseBase):
         self.user_id = "soeren"
         self.resource_id = uuid.uuid1()
         self.document = pickle.dumps({"Status":"running", "URL":"/bla/bla"})
-        self.log = ResourceLogger(global_config.REDIS_SERVER_URL,
-                                  global_config.REDIS_SERVER_PORT)
+
+        redis_args = (global_config.REDIS_SERVER_URL, global_config.REDIS_SERVER_PORT)
+        if global_config.REDIS_SERVER_PW is not None:
+            redis_args = (*redis_args, global_config.REDIS_SERVER_PW)
+        self.log = ResourceLogger(*redis_args)
+        del redis_args
+
 
     def tearDown(self):
         self.app_context.pop()


### PR DESCRIPTION
This PR suggests to let actinia connect to a password restricted redis db. If no password is set in the config, no password is used but if one is set (with redis_server_pw) it will be used. Errors occur if redis requires a password but none is set or the wrong one or if a password is set but redis requires none. This is default redis behaviour.

This was tested with startup, "api/v1/locations" request and "/api/v1/locations/nc_spm_08/processing_async_export" request including polling.