### PR TITLE
switch docker build based on master instead of release

### DIFF
--- a/docker/actinia-core/Dockerfile
+++ b/docker/actinia-core/Dockerfile
@@ -6,7 +6,10 @@ LABEL maintainer="tawalika@mundialis.de,bettge@mundialis.de,neteler@mundialis.de
 ARG SOURCE_GIT_URL=https://github.com
 ARG SOURCE_GIT_REMOTE=mundialis
 ARG SOURCE_GIT_REPO=actinia_core
-ARG SOURCE_GIT_TAG=stable
+# can be "tags" (for tag) or "heads" (for) branch
+ARG SOURCE_GIT_TYPE=heads
+# can be a tag name or branch name
+ARG SOURCE_GIT_REF=master
 
 ENV GDAL_CACHEMAX=2000
 ENV GRASS_COMPRESSOR=ZSTD
@@ -93,8 +96,9 @@ RUN update-alternatives --remove python /usr/bin/python3
 
 # Install actinia-core
 WORKDIR /src
-ADD https://api.github.com/repos/$SOURCE_GIT_REMOTE/$SOURCE_GIT_REPO/git/refs/tags/$SOURCE_GIT_TAG version.json
-RUN git clone -b ${SOURCE_GIT_TAG} --single-branch ${SOURCE_GIT_URL}/${SOURCE_GIT_REMOTE}/${SOURCE_GIT_REPO}.git actinia_core
+
+ADD https://api.github.com/repos/$SOURCE_GIT_REMOTE/$SOURCE_GIT_REPO/git/refs/$SOURCE_GIT_TYPE/$SOURCE_GIT_REF version.json
+RUN git clone -b ${SOURCE_GIT_REF} --single-branch ${SOURCE_GIT_URL}/${SOURCE_GIT_REMOTE}/${SOURCE_GIT_REPO}.git actinia_core
 
 WORKDIR /src/actinia_core
 RUN pip3 install -r requirements.txt && python3 setup.py install

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,8 @@ services:
         - SOURCE_GIT_URL=https://github.com
         - SOURCE_GIT_REMOTE=mundialis
         - SOURCE_GIT_REPO=actinia_core
-        - SOURCE_GIT_TAG=latest
+        - SOURCE_GIT_TYPE=heads
+        - SOURCE_GIT_REF=master
     image: actinia-core:latest
     volumes:
       - ./actinia-core-data/grassdb:/actinia_core/grassdb:Z


### PR DESCRIPTION
This concerns only the docker build. Before the source was fetched by release tag. Now it is switched to master branch to always build latest code.