### PR TITLE
add production docker config and remove GISBASE (fixed in GRASS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ MANIFEST
 docker/redis_data/dump.rdb
 !docker/actinia-core/actinia.cfg
 !docker/actinia-core-dev/actinia.cfg
+!docker/actinia-core-prod/actinia.cfg
 docker/build
 docker/actinia-core-data/grassdb
 docker/actinia-core-data/resources

--- a/docker/actinia-core-prod/Dockerfile
+++ b/docker/actinia-core-prod/Dockerfile
@@ -1,0 +1,14 @@
+FROM mundialis/actinia-core:latest
+
+# Copy actinia config file and start scripts
+COPY actinia.cfg /etc/default/actinia
+COPY start.sh /src/start.sh
+
+WORKDIR /src/actinia_core
+RUN python3 setup.py install
+
+EXPOSE 8088
+EXPOSE 9191
+
+ENTRYPOINT ["/bin/bash"]
+CMD ["/src/start.sh"]

--- a/docker/actinia-core-prod/actinia.cfg
+++ b/docker/actinia-core-prod/actinia.cfg
@@ -1,0 +1,44 @@
+[GRASS]
+grass_gis_start_script = /usr/local/bin/grass
+grass_database = /actinia_core/grassdb
+grass_user_database = /actinia_core/userdata
+grass_tmp_database = /actinia_core/workspace/temp_db
+grass_resource_dir = /actinia_core/resources
+grass_addon_path = /root/.grass7/addons/
+grass_gis_base = /usr/local/grass7
+grass_modules_xml_path = /usr/local/grass7/gui/wxpython/xml/module_items.xml
+grass_default_location = nc_spm_08
+
+[API]
+plugins = ["actinia_statistic_plugin"]
+force_https_urls = False
+
+[LIMITS]
+max_cell_limit = 2000000
+process_time_limt = 60
+process_num_limit = 20
+number_of_workers = 3
+
+[REDIS]
+redis_server_url =  redis
+redis_server_port = 6379
+redis_server_pw = pass
+redis_queue_server_url = redis
+redis_queue_server_port = 6379
+worker_queue_name = actinia_job
+worker_logfile = /actinia_core/workspace/tmp/actinia_worker
+
+[LOGGING]
+log_interface = fluentd
+log_fluent_host = fluentd
+log_fluent_port = 24224
+log_level = 1
+
+[MISC]
+tmp_workdir = /actinia_core/workspace/tmp
+download_cache = /actinia_core/workspace/download_cache
+secret_key = token_signing_key_changeme
+
+[MANAGEMENT]
+default_user = user
+default_user_group = group

--- a/docker/actinia-core-prod/start.sh
+++ b/docker/actinia-core-prod/start.sh
@@ -7,18 +7,6 @@ mkdir -p /actinia_core/workspace/temp_db
 mkdir -p /actinia_core/workspace/tmp
 mkdir -p /actinia_core/resources
 
-# copy pgpass from mounted (!) file
-cp /mnt/pgpass/.pgpass $HOME/.pgpass
-chmod 0600 $HOME/.pgpass
-
-# copy db.login file from mounted (!) file
-cp /mnt/pgpass/.grass7 $HOME/.grass7/dblogin
-chmod 0600 $HOME/.grass7/dblogin
-
-# copy db.login file to actinia-core tmp location
-mkdir -p /tmp/:/root/.grass7
-cp /root/.grass7/dblogin /tmp/:/root/.grass7/
-
 # Create default location in mounted (!) directory
 grass -text -e -c 'EPSG:25832' /actinia_core/grassdb/utm32n
 grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong
@@ -26,10 +14,9 @@ grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong
 # created here, because set in sample config as default location
 grass -text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
 
-actinia-user create -u actinia-gdi -w actinia-gdi -r superadmin -g superadmin -c 100000000000 -n 1000 -t 31536000
-actinia-user update -u actinia-gdi -w actinia-gdi
+gunicorn -b 0.0.0.0:8088 -w 1 actinia_core.main:flask_app
 status=$?
 if [ $status -ne 0 ]; then
-  echo "Failed to start actinia-user: $status"
+  echo "Failed to start actinia_core/main.py: $status"
   exit $status
 fi

--- a/docker/actinia-core/start.sh
+++ b/docker/actinia-core/start.sh
@@ -20,13 +20,11 @@ mkdir -p /tmp/:/root/.grass7
 cp /root/.grass7/dblogin /tmp/:/root/.grass7/
 
 # Create default location in mounted (!) directory
-export GISBASE="/usr/local/grass77/"
 grass -text -e -c 'EPSG:25832' /actinia_core/grassdb/utm32n
 grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong
 # TODO: use this location for tests and integrate sample data, see README
 # created here, because set in sample config as default location
 grass -text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
-export GISBASE=""
 
 actinia-user create -u actinia-gdi -w actinia-gdi -r superadmin -g superadmin -c 100000000000 -n 1000 -t 31536000
 actinia-user update -u actinia-gdi -w actinia-gdi

--- a/docker/docker-compose-prod.yml
+++ b/docker/docker-compose-prod.yml
@@ -8,10 +8,10 @@ services:
       - ./actinia-core-data/grassdb:/actinia_core/grassdb:Z
       - ./actinia-core-data/pgpass:/mnt/pgpass:Z
       - ./actinia-core-data/geodata_dir:/mnt/geodata:Z
-      - ./actinia-core-data/userdata:/actinia_core/userdata"
-      - ./actinia-core-data/workspace/temp_db:/actinia_core/workspace/temp_db"
-      - ./actinia-core-data/workspace/tmp:/actinia_core/workspace/tmp"
-      - ./actinia-core-data/resources:/actinia_core/resources"
+      - ./actinia-core-data/userdata:/actinia_core/userdata:Z
+      - ./actinia-core-data/workspace/temp_db:/actinia_core/workspace/temp_db:Z
+      - ./actinia-core-data/workspace/tmp:/actinia_core/workspace/tmp:Z
+      - ./actinia-core-data/resources:/actinia_core/resources:Z
     ports:
       - "8088:8088"
     depends_on:

--- a/docker/docker-compose-prod.yml
+++ b/docker/docker-compose-prod.yml
@@ -1,0 +1,33 @@
+version: "3"
+services:
+
+  actinia-core:
+    build:
+      context: actinia-core-prod/
+    volumes:
+      - ./actinia-core-data/grassdb:/actinia_core/grassdb:Z
+      - ./actinia-core-data/pgpass:/mnt/pgpass:Z
+      - ./actinia-core-data/geodata_dir:/mnt/geodata:Z
+      - ./actinia-core-data/userdata:/actinia_core/userdata"
+      - ./actinia-core-data/workspace/temp_db:/actinia_core/workspace/temp_db"
+      - ./actinia-core-data/workspace/tmp:/actinia_core/workspace/tmp"
+      - ./actinia-core-data/resources:/actinia_core/resources"
+    ports:
+      - "8088:8088"
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:5.0.4-alpine
+    volumes:
+      - ./redis_data:/data
+    environment:
+      - REDIS_PASS_FILE=/data/config/.redis
+    command: [
+      "sh", "-c",
+      '
+      docker-entrypoint.sh
+      "/data/config/redis.conf"
+      --requirepass "$$(cat $$REDIS_PASS_FILE)"
+      '
+    ]


### PR DESCRIPTION
This PR adds a docker-compose-prod.yml for production environments. It also removes the setting of the GISBASE environment variable before starting GRASS GIS (fixed in GRASS GIS itself)