### PR TITLE
use copy instead of git pull in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+docker
+!docker/actinia-core/snap
+!docker/actinia-core/actinia.cfg
+!docker/actinia-core/start.sh
+!docker/actinia-core/start-dev.sh
+.gitignore
+.github
+.travis
+.travis.yml
+.eggs
+.pytest_cache
+build
+dist

--- a/docker/actinia-core/Dockerfile
+++ b/docker/actinia-core/Dockerfile
@@ -3,14 +3,6 @@ FROM mundialis/grass-py3-pdal
 LABEL authors="Carmen Tawalika,Anika Bettge,Markus Neteler,Sören Gebbert"
 LABEL maintainer="tawalika@mundialis.de,bettge@mundialis.de,neteler@mundialis.de,soerengebbert@gmail.com"
 
-ARG SOURCE_GIT_URL=https://github.com
-ARG SOURCE_GIT_REMOTE=mundialis
-ARG SOURCE_GIT_REPO=actinia_core
-# can be "tags" (for tag) or "heads" (for) branch
-ARG SOURCE_GIT_TYPE=heads
-# can be a tag name or branch name
-ARG SOURCE_GIT_REF=master
-
 ENV GDAL_CACHEMAX=2000
 ENV GRASS_COMPRESSOR=ZSTD
 
@@ -81,14 +73,13 @@ RUN grass --tmp-location EPSG:4326 --exec g.extension -s extension=i.cutlines &&
 RUN apt-get install default-jdk maven -y
 ENV JAVA_HOME "/usr/lib/jvm/java-11-openjdk-amd64"
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-COPY snap /src/snap
+COPY docker/actinia-core/snap /src/snap
 RUN sh /src/snap/install.sh
 RUN update-alternatives --remove python /usr/bin/python3
 
 # Install actinia-core
-WORKDIR /src
-ADD https://api.github.com/repos/$SOURCE_GIT_REMOTE/$SOURCE_GIT_REPO/git/refs/$SOURCE_GIT_TYPE/$SOURCE_GIT_REF version.json
-RUN git clone -b ${SOURCE_GIT_REF} --single-branch ${SOURCE_GIT_URL}/${SOURCE_GIT_REMOTE}/${SOURCE_GIT_REPO}.git actinia_core
+
+COPY . /src/actinia_core
 
 # set link to match actinia default config (needed for tests)
 RUN ln -s /actinia_core /root/actinia
@@ -117,9 +108,9 @@ WORKDIR /grassdb
 VOLUME /grassdb
 
 # Copy actinia config file and start scripts
-COPY actinia.cfg /etc/default/actinia
-COPY start.sh /src/start.sh
-COPY start-dev.sh /src/start-dev.sh
+COPY docker/actinia-core/actinia.cfg /etc/default/actinia
+COPY docker/actinia-core/start.sh /src/start.sh
+COPY docker/actinia-core/start-dev.sh /src/start-dev.sh
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/src/start.sh"]

--- a/docker/actinia-core/README.md
+++ b/docker/actinia-core/README.md
@@ -7,3 +7,47 @@ https://hub.docker.com/r/mundialis/actinia-core
 ## Background info
 
 This docker image is based on https://hub.docker.com/r/mundialis/grass-py3-pdal which provides GRASS GIS 7.8 (release branch, grass78) with python3 and PDAL support.
+
+The Dockerfile contained in this folder is used to build to dockerhub.
+If you want to build manually...
+## mind the build context!
+
+Clone this repository and change directory:
+
+```bash
+$ git clone https://github.com/mundialis/actinia_core.git
+$ cd actinia_core
+```
+
+__Build the docker with__:
+
+```bash
+$ docker build \
+         --file docker/actinia-core/Dockerfile \
+         --tag actinia-core:latest .
+```
+
+View the images available using `sudo docker images` and open a bash terminal with:
+
+```bash
+$ docker run -it --entrypoint=/bin/bash actinia-core:latest
+root@c5e3b72ad8ba:/grassdb#
+```
+
+__To build a stable version__:
+
+change to the tag you want to build (only supported from v0.2.3):
+```bash
+$ git checkout v0.2.3
+```
+
+and build and enter with:
+
+```bash
+$ docker build \
+        --file docker/actinia-core/Dockerfile \
+        --tag actinia-core:stable .
+
+$ docker run -it --entrypoint=/bin/bash actinia-core:latest
+root@c5e3b72ad8ba:/grassdb#
+```


### PR DESCRIPTION
This way, it will be possible to test branches and tags or even local changes by simply copying the current source code into the docker instead of specifying branch or tag to checkout from github.