### PR TITLE
update build context in docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,8 @@ services:
 
   actinia-core:
     build:
-      context: actinia-core/
+      context: ./..
+      dockerfile: docker/actinia-core/Dockerfile
       args:
         - SOURCE_GIT_URL=https://github.com
         - SOURCE_GIT_REMOTE=mundialis


### PR DESCRIPTION
As the actinia-core Dockerfile was updated recently to use `copy` instead of `git clone`, the build context changed. Before, the build context pointed to the folder `docker/actinia-core` which now changed to the root directory of this git repository. In the docker-compose.yaml, the build context needed to be adjusted accordingly to enable commands using COPY (e.g. `COPY docker/actinia-core/snap /src/snap`) to find the source to be copied.
This PR fixes the build context when using docker-compose.
