### PR TITLE
make base dockerimage explicit (grass78)

### DIFF
--- a/docker/actinia-core/Dockerfile
+++ b/docker/actinia-core/Dockerfile
@@ -1,4 +1,4 @@
-FROM mundialis/grass-py3-pdal
+FROM mundialis/grass-py3-pdal:stable-ubuntu
 
 LABEL authors="Carmen Tawalika,Anika Bettge,Markus Neteler,Sören Gebbert"
 LABEL maintainer="tawalika@mundialis.de,bettge@mundialis.de,neteler@mundialis.de,soerengebbert@gmail.com"


### PR DESCRIPTION
As we use grass-py3-pdal as baseimage which changed default version in latest image from grass78 (stable) to grass79 (develop version), we need to explicitly set the docker tag in the image.