### PR TITLE
use git tag for actinia version

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,12 +5,6 @@ services:
     build:
       context: ./..
       dockerfile: docker/actinia-core/Dockerfile
-      args:
-        - SOURCE_GIT_URL=https://github.com
-        - SOURCE_GIT_REMOTE=mundialis
-        - SOURCE_GIT_REPO=actinia_core
-        - SOURCE_GIT_TYPE=heads
-        - SOURCE_GIT_REF=master
     image: actinia-core:latest
     volumes:
       - ./actinia-core-data/grassdb:/actinia_core/grassdb:Z

--- a/src/actinia_core/version.py
+++ b/src/actinia_core/version.py
@@ -35,6 +35,7 @@ __email__ = "soerengebbert@googlemail.com"
 from flask import make_response, jsonify
 from .resources.common.app import flask_app, API_VERSION, URL_PREFIX
 from .resources.common.config import global_config
+from . import __version__
 
 # Return the version of Actinia Core as REST API call
 @flask_app.route(URL_PREFIX + '/version')
@@ -44,5 +45,10 @@ def version():
     Returns: Response
 
     """
-    info = {"version":API_VERSION, "plugins":",".join(global_config.PLUGINS)}
+    info = {"version":__version__, "plugins":",".join(global_config.PLUGINS)}
+
+    if 'actinia_gdi' in global_config.PLUGINS:
+        from actinia_gdi import __version__ as actinia_gdi_version
+        info['plugin_versions'] = {'actinia_gdi': actinia_gdi_version}
+
     return make_response(jsonify(info), 200)


### PR DESCRIPTION
Before, the version of actinia was hardcoded in src/actinia_core/resources/common/app.py in API_VERSION="v1". It was used to created the api path (/api/v1/) and to display the version for /api/v1/version. Now for the latter, the version will be retrieved from the git version (see `git describe`, "Default versioning scheme" on https://pypi.org/project/setuptools-scm/ ). This might lead to weird looking versions during development but should create nice semver versions for production.
Example (during development):
```
{
  "plugin_version": {
    "actinia_gdi": "0.1.1.post0.dev8+g5f2c551.dirty"
  },
  "plugins": "actinia_gdi",
  "version": "0.2.2.post0.dev13+g9382e50.dirty"
}
```
After merge I would create a release v0.99.0 to closely align API version (v1 in path), actinia-version, github release tag version and Docker tag version. (not 1.0.0, waiting for https://trac.osgeo.org/grass/ticket/3928)