### PR TITLE
fix version to not be dirty after release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@ docker
 !docker/actinia-core/actinia.cfg
 !docker/actinia-core/start.sh
 !docker/actinia-core/start-dev.sh
-.gitignore
 .github
 .travis
 .travis.yml

--- a/docker/README.md
+++ b/docker/README.md
@@ -41,9 +41,9 @@ __See below for production deployment__.
 
 For actinia_core development, run and enter the running container (in a separate terminal):
 ```
-docker-compose run --rm --entrypoint /bin/bash -v $HOME/repos/actinia_core/src:/src/actinia_core/src actinia-core
+docker-compose run --rm --service-ports --entrypoint /bin/bash -v $HOME/repos/actinia_core/src:/src/actinia_core/src actinia-core
 
-docker-compose -f docker-compose-dev.yml run --rm --entrypoint /bin/bash -v $HOME/repos/actinia/actinia_core/src:/src/actinia_core/src -v $HOME/repos/actinia/actinia_core/scripts:/src/actinia_core/scripts actinia-core```
+docker-compose -f docker-compose-dev.yml run --rm --service-ports --entrypoint /bin/bash -v $HOME/repos/actinia/actinia_core/src:/src/actinia_core/src -v $HOME/repos/actinia/actinia_core/scripts:/src/actinia_core/scripts actinia-core
 ```
 
 Inside the container, you can run GRASS GIS with:

--- a/docker/actinia-core/Dockerfile
+++ b/docker/actinia-core/Dockerfile
@@ -85,6 +85,13 @@ COPY . /src/actinia_core
 RUN ln -s /actinia_core /root/actinia
 
 WORKDIR /src/actinia_core
+# necessary to be even with git for clean version
+RUN git checkout .
+# update build tools
+RUN python3 -m pip install --user --upgrade setuptools wheel
+# create build
+RUN python3 setup.py sdist bdist_wheel
+# install
 RUN pip3 install -r requirements.txt && python3 setup.py install
 ## TODO: fix tests
 #\


### PR DESCRIPTION
This PR is a follow up to #57. Instead of the version shown there, after a clean release it is shown like this:

```
{
  "plugins": "actinia_statistic_plugin", 
  "version": "0.99.0+ga8ff003.dirty"
}
```

This "not clean" part are files which are not copied into the docker but commited (some docker files not relevant for the main build, ...)
This PR suggests to conduct a `git pull` to make the version clean again.