### PR TITLE
Data source URLs: Update to new `@` delimiter character

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -414,7 +414,7 @@ Store the following script as text file `ace_dtm_statistics.sh`:
 ```bash
 # grass78 ~/grassdata/nc_spm_08/user1/
 # Import the web resource `elev_ned_30m.tif` and set the region to the imported map
-g.region raster=elev+https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif -ap
+g.region raster=elev@https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif -ap
 # Compute univariate statistics
 r.univar map=elev
 r.info elev
@@ -510,7 +510,7 @@ Store the following script as text file `/tmp/ace_segmentation.sh`:
 # Import the web resource and set the region to the imported map
 # we apply a trick for the import of multi-band GeoTIFFs:
 # install with: g.extension importer
-importer raster=ortho2010+https://apps.mundialis.de/workshops/osgeo_ireland2017/north_carolina/ortho2010_t792_subset_20cm.tif
+importer raster=ortho2010@https://apps.mundialis.de/workshops/osgeo_ireland2017/north_carolina/ortho2010_t792_subset_20cm.tif
 # The importer has created three new raster maps, one for each band in the geotiff file
 # stored them in an image group
 r.info map=ortho2010.1

--- a/scripts/ace
+++ b/scripts/ace
@@ -48,7 +48,7 @@ export ACTINIA_URL='https://actinia.mundialis.de/latest'
 # Example script for actinia with import and export options
 # grass78 ~/grassdata/nc_spm_08/user1/
 import_export = """
-g.region raster=elev+https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif -p
+g.region raster=elev@https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif -p
 r.univar map=elev
 r.info elev
 r.slope.aspect elevation=elev slope=slope_elev+GTiff
@@ -539,7 +539,7 @@ def main(script: str, version: bool, list_jobs: str, info_job: str,
 
       \b
       # Import the web resource and set the region to the imported map
-      g.region raster=elev+https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif -ap
+      g.region raster=elev@https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif -ap
       # Compute univariate statistics
       r.univar map=elev
       r.info elev

--- a/scripts/ace_test.sh
+++ b/scripts/ace_test.sh
@@ -36,7 +36,7 @@ ${ace} --location nc_spm_08 --list-strds PERMANENT
 # Create some commands with import and export options
 cat << EOF > /tmp/commands.sh
 # Import the web resource and set the region to the imported map
-g.region raster=elev+https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif -ap
+g.region raster=elev@https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif -ap
 # Compute univariate statistics
 r.univar map=elev
 r.info elev

--- a/scripts/exporter/exporter.html
+++ b/scripts/exporter/exporter.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-<em><b>exporter</b></em> - export of raster and vector maps from actinia.
+<em><b>exporter</b></em> exports raster and vector maps from actinia.
 
 <h2>AUTHOR</h2>
 

--- a/scripts/exporter/exporter.py
+++ b/scripts/exporter/exporter.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-#
+
 ############################################################################
 #
 # MODULE:       Actinia exporter
+#
 # AUTHOR(S):    Soeren Gebbert
 #
 # PURPOSE:      Facilitates creation of raster MASK
 #
-# COPYRIGHT:    (C) 2018 by  Sören Gebbert and mundialis GmbH & Co. KG
+# COPYRIGHT:    (C) 2018-2019 by Sören Gebbert and mundialis GmbH & Co. KG
 #
 #               This program is free software under the GNU General Public
 #               License (>=v3). Read the file COPYING that comes with GRASS
@@ -16,10 +17,11 @@
 #############################################################################
 
 #%module
-#% description: Actinia exporter module
+#% description: Actinia exporter module supporting raster and vector data.
+#% keyword: actinia
+#% keyword: export
 #% keyword: raster
 #% keyword: vector
-#% keyword: actinia
 #% overwrite: no
 #%end
 #%option G_OPT_R_OUTPUT
@@ -30,7 +32,7 @@
 #%end
 #%option G_OPT_V_OUTPUT
 #% key: vector
-#% label: Name of vector map to be exported in actinia
+#% label: Name of vector map to be exported by actinia
 #% required: NO
 #% guisection: Vector
 #%end

--- a/scripts/importer/importer.html
+++ b/scripts/importer/importer.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-<em><b>importer</b></em> - import of raster and vector maps into actinia.
+<em><b>importer</b></em> imports raster and vector maps into actinia.
 
 <h2>AUTHOR</h2>
 

--- a/scripts/importer/importer.py
+++ b/scripts/importer/importer.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-#
+
 ############################################################################
 #
 # MODULE:       Actinia importer
+#
 # AUTHOR(S):    Soeren Gebbert
 #
 # PURPOSE:      Facilitates creation of raster MASK
 #
-# COPYRIGHT:    (C) 2018 by  Sören Gebbert and mundialis GmbH & Co. KG
+# COPYRIGHT:    (C) 2018-2019 by Sören Gebbert and mundialis GmbH & Co. KG
 #
 #               This program is free software under the GNU General Public
 #               License (>=v3). Read the file COPYING that comes with GRASS
@@ -16,21 +17,22 @@
 #############################################################################
 
 #%module
-#% description: Actinia importer module
+#% description: Actinia importer module supporting raster and vector data.
+#% keyword: actinia
+#% keyword: import
 #% keyword: raster
 #% keyword: vector
-#% keyword: actinia
 #% overwrite: no
 #%end
 #%option G_OPT_R_INPUT
 #% key: raster
-#% description: Name of raster map to import by actinia
+#% description: Name of raster map to be imported by actinia
 #% required: NO
 #% guisection: Raster
 #%end
 #%option G_OPT_V_INPUT
 #% key: vector
-#% label: Name of vector map to import in actinia
+#% label: Name of vector map to be imported by actinia
 #% required: NO
 #% guisection: Vector
 #%end

--- a/src/actinia_core/resources/common/geodata_download_importer.py
+++ b/src/actinia_core/resources/common/geodata_download_importer.py
@@ -22,7 +22,7 @@
 #######
 
 """
-Sentinel-2A processing commands
+Geodata processing commands
 """
 import os
 import requests
@@ -53,7 +53,7 @@ class GeoDataDownloadImportSupport(object):
 
     def __init__(self, config, temp_file_path, download_cache,
                  send_resource_update, message_logger, url_list):
-        """ A collection of functions to generate Landsat4-8 scene related import and processing
+        """ A collection of functions to generate geodata related import and processing
         commands. Each function returns a process chain that can be executed
         by the async processing classes.
 


### PR DESCRIPTION
Following the merge of https://github.com/OSGeo/grass/pull/175 in GRASS GIS, this
change replaces `+` with `@`.

Rationale:
Since `+` is used in algebraic expressions incl. v.db.update, this char is unsuitable
for the indication of external URL resourcs as used by the importer of
actinia (https://github.com/mundialis/actinia_core/).

Additional some minor message cosmetics have been done.