### PR TITLE
increase java_max_mem to avoid NullPointer exception

### DIFF
--- a/docker/actinia-core/Dockerfile
+++ b/docker/actinia-core/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get upgrade -y && \
     libcurl4-gnutls-dev \
     libpython3-all-dev \
     moreutils \
-    subversion \
     python3 \
     python3-dateutil \
     python3-dev \
@@ -32,6 +31,7 @@ RUN apt-get update && apt-get upgrade -y && \
     python3-ply \
     redis-server \
     redis-tools \
+    subversion \
     unzip \
     vim \
     wget \
@@ -74,7 +74,7 @@ RUN apt-get install default-jdk maven -y
 ENV JAVA_HOME "/usr/lib/jvm/java-11-openjdk-amd64"
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 COPY docker/actinia-core/snap /src/snap
-RUN sh /src/snap/install.sh
+RUN bash /src/snap/install.sh
 RUN update-alternatives --remove python /usr/bin/python3
 
 # Install actinia-core
@@ -110,6 +110,7 @@ RUN pip3 install -r requirements.txt && python3 setup.py install
 # Reduce the image size
 RUN apt-get autoremove -y
 RUN apt-get clean -y
+RUN rm -rf /src/snap
 
 # Data directory
 WORKDIR /grassdb

--- a/docker/actinia-core/snap/install.sh
+++ b/docker/actinia-core/snap/install.sh
@@ -1,10 +1,12 @@
-# /bin/sh
+#!/bin/bash
 
 # https://senbox.atlassian.net/wiki/spaces/SNAP/pages/30539778/Install+SNAP+on+the+command+line
 # https://senbox.atlassian.net/wiki/spaces/SNAP/pages/30539785/Update+SNAP+from+the+command+line
 
 # http://step.esa.int/main/download/snap-download/
 SNAPVER=7
+# avoid NullPointer exception during S-1 processing
+java_max_mem=10G
 
 # set JAVA_HOME (done in Docker as well)
 export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
@@ -27,5 +29,15 @@ sh /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh -q -varfile /src/snap/response.va
 /usr/local/snap/bin/snappy-conf /usr/bin/python3
 (cd /root/.snap/snap-python/snappy && python3 setup.py install)
 
+# increase the JAVA VM size to avoid NullPointer exception in Snappy during S-1 processing
+(cd /root/.snap/snap-python/snappy && sed -i "s/^java_max_mem:.*/java_max_mem: $java_max_mem/" snappy.ini)
+
+# get minor python version
+PYMINOR=$(python3 -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(minor)')
+(cd /usr/local/lib/python3.$PYMINOR/dist-packages/snappy/ && sed -i "s/^java_max_mem:.*/java_max_mem: $java_max_mem/" snappy.ini)
+
 # test
 /usr/bin/python3 -c 'from snappy import ProductIO'
+
+# cleanup installer
+rm -f /src/snap/esa-snap_all_unix_${SNAPVER}_0.sh


### PR DESCRIPTION
- increase `java_max_mem` to avoid NullPointer exception in Snappy during S-1 processing
- clean up /src to reduce image size
- Dockerfile: SNAP wants the current folder '.' included in LD_LIBRARY_PATH
- explicitely use bash and not sh to run snap/install.sh