### PR TITLE
use csv to install GRASS GIS addons in a loop

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 docker
 !docker/actinia-core/snap
+!docker/actinia-core/grass_addons_list.csv
 !docker/actinia-core/actinia.cfg
 !docker/actinia-core/start.sh
 !docker/actinia-core/start-dev.sh

--- a/docker/actinia-core/Dockerfile
+++ b/docker/actinia-core/Dockerfile
@@ -64,12 +64,9 @@ RUN grass --tmp-location EPSG:4326 --exec g.version -rge
 WORKDIR /src
 # Install the d.rast.multi module to render several maps at once
 RUN git clone https://huhabla@bitbucket.org/huhabla/d_rast_multi.git d.rast.multi
-RUN grass --tmp-location EPSG:4326 --exec g.extension -s extension=d.rast.multi url=/src/d.rast.multi
 
-# install some GRASS GIS addons
-RUN grass --tmp-location EPSG:4326 --exec g.extension -s extension=i.cutlines && \
-    grass --tmp-location EPSG:4326 --exec g.extension -s extension=r.colors.out_sld && \
-    grass --tmp-location EPSG:4326 --exec g.extension -s extension=v.centerpoint
+COPY docker/actinia-core/grass_addons_list.csv
+RUN while IFS=, read -r ADDON SERVER; do unset URL; test -z $SERVER || URL="url=$SERVER"; grass --tmp-location EPSG:4326 --exec g.extension -s extension=$ADDON $URL;done < rass_addons_list.txt
 
 # install SNAPPY
 RUN apt-get install default-jdk maven -y

--- a/docker/actinia-core/Dockerfile
+++ b/docker/actinia-core/Dockerfile
@@ -66,7 +66,7 @@ WORKDIR /src
 RUN git clone https://huhabla@bitbucket.org/huhabla/d_rast_multi.git d.rast.multi
 
 COPY docker/actinia-core/grass_addons_list.csv
-RUN while IFS=, read -r ADDON SERVER; do unset URL; test -z $SERVER || URL="url=$SERVER"; grass --tmp-location EPSG:4326 --exec g.extension -s extension=$ADDON $URL;done < rass_addons_list.txt
+RUN while IFS=, read -r ADDON SERVER; do unset URL; test -z $SERVER || URL="url=$SERVER"; grass --tmp-location EPSG:4326 --exec g.extension -s extension=$ADDON $URL;done < grass_addons_list.txt
 
 # install SNAPPY
 RUN apt-get install default-jdk maven -y

--- a/docker/actinia-core/Dockerfile
+++ b/docker/actinia-core/Dockerfile
@@ -65,8 +65,8 @@ WORKDIR /src
 # Install the d.rast.multi module to render several maps at once
 RUN git clone https://huhabla@bitbucket.org/huhabla/d_rast_multi.git d.rast.multi
 
-COPY docker/actinia-core/grass_addons_list.csv
-RUN while IFS=, read -r ADDON SERVER; do unset URL; test -z $SERVER || URL="url=$SERVER"; grass --tmp-location EPSG:4326 --exec g.extension -s extension=$ADDON $URL;done < grass_addons_list.txt
+COPY docker/actinia-core/grass_addons_list.csv /src/grass_addons_list.csv
+RUN while IFS=, read -r ADDON SERVER; do unset URL; test -z $SERVER || URL="url=$SERVER"; grass --tmp-location EPSG:4326 --exec g.extension -s extension=$ADDON $URL;done < /src/grass_addons_list.csv
 
 # install SNAPPY
 RUN apt-get install default-jdk maven -y

--- a/docker/actinia-core/grass_addons_list.csv
+++ b/docker/actinia-core/grass_addons_list.csv
@@ -1,0 +1,4 @@
+d.rast.multi,/src/d.rast.multi
+i.cutlines,
+r.colors.out_sld,
+v.centerpoint,

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ numpy==1.15.4
 pandas
 passlib==1.7.1
 ply==3.11
+pyproj==1.9.6
 python-magic==0.4.15
 scikit-learn
 Shapely

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ numpy==1.15.4
 pandas
 passlib==1.7.1
 ply==3.11
-pyproj==1.9.6
 python-magic==0.4.15
 scikit-learn
 Shapely


### PR DESCRIPTION
This PR suggests to use a CSV file to list all GRASS GIS extensions. In the Dockerfile, it iterates through it and uses g.extensions to install all.