### PR TITLE
Fix cancel/termination operation for redis version >= 3.0.0

### DIFF
--- a/src/actinia_core/resources/common/redis_resources.py
+++ b/src/actinia_core/resources/common/redis_resources.py
@@ -139,7 +139,7 @@ class RedisResourceInterface(RedisBaseInterface):
 
         """
         return self.redis_server.setex(self.resource_id_termination_prefix + resource_id,
-                                       expiration, True)
+                                       expiration, 1)
 
     def get(self, resource_id):
         """Get the resource entry if exists


### PR DESCRIPTION
There are some changes in redis (https://github.com/andymccurdy/redis-py/blob/master/CHANGES) so that the cancel operation does not work for redis>=2.10.6 (and rq>=0.10.0).
This is caused by the change in 3.0.0: Only bytes, strings and numbers (ints, longs and floats) are acceptablefor keys and values. Previously redis-py attempted to cast other types
to str() and store the result. This caused must confusion and frustration
when passing boolean values (cast to 'True' and 'False') or None values
(cast to 'None'). It is now the user's responsibility to cast all
key names and values to bytes, strings or numbers before passing the
value to redis-py.