### PR TITLE
Switch alpine docker to alpine 3.11 and compiled pdal

### DIFF
--- a/docker/actinia-core-alpine/Dockerfile
+++ b/docker/actinia-core-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM mundialis/grass-py3-pdal:stable-alpine as grass
-FROM mundialis/esa-snap:7.0 as snap
-FROM mundialis/actinia-core:alpine-build-pkgs as build
+FROM mundialis/esa-snap:7.0v1 as snap
+FROM mundialis/actinia-core:alpine-build-pkgs_v2 as build
 
 LABEL authors="Carmen Tawalika,Anika Bettge,Markus Neteler,Sören Gebbert"
 LABEL maintainer="tawalika@mundialis.de,bettge@mundialis.de,neteler@mundialis.de,soerengebbert@gmail.com"
@@ -18,7 +18,7 @@ RUN python3 setup.py sdist bdist_wheel -d /build
 # RUN python3 -m pep517.build --out-dir /build . && \
 
 
-FROM mundialis/actinia-core:alpine-runtime-pkgs as actinia
+FROM mundialis/actinia-core:alpine-runtime-pkgs_v2 as actinia
 
 ENV LC_ALL "en_US.UTF-8"
 ENV GDAL_CACHEMAX=2000
@@ -48,10 +48,6 @@ RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
 # GRASS GIS addons BUILD
 RUN git clone https://github.com/mundialis/openeo-addons.git /src/openeo-addons
 COPY docker/grass_addons_list.csv /src/grass_addons_list.csv
-# TODO: remove patch when python 3.8.2 is here
-RUN apk add curl
-RUN curl -L https://github.com/mmacata/alpine-python381-patch/releases/download/0.0.0/python3-3.8.1-r1.apk > /src/python3-3.8.1-r1.apk
-RUN apk add --allow-untrusted /src/python3-3.8.1-r1.apk
 
 RUN while IFS=, read -r ADDON SERVER; do unset URL; test -z $SERVER || URL="url=$SERVER"; grass --tmp-location EPSG:4326 --exec g.extension -s extension=$ADDON $URL;done < /src/grass_addons_list.csv
 

--- a/docker/actinia-core-alpine/Dockerfile_build_pkgs
+++ b/docker/actinia-core-alpine/Dockerfile_build_pkgs
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.11
 
 ENV BUILD_PACKAGES="\
     gcc \
@@ -23,4 +23,5 @@ ENV REQUIREMENTS_WHEEL_PACKAGES="\
     "
 
 RUN apk update && apk add $BUILD_PACKAGES $REQUIREMENTS_WHEEL_PACKAGES
+RUN python3 -m ensurepip && pip3 install --upgrade pip
 RUN pip3 install --upgrade pip pep517 wheel

--- a/docker/actinia-core-alpine/Dockerfile_runtime_pkgs
+++ b/docker/actinia-core-alpine/Dockerfile_runtime_pkgs
@@ -1,14 +1,26 @@
-#FROM mundialis/actinia-core:alpine-build-pkgs
-FROM actinia-core:alpine-build-pkgs
+FROM mundialis/docker-pdal:1.8.0 as pdal
+FROM mundialis/actinia-core:alpine-build-pkgs_v2
 
 ENV SNAPPY_RUNTIME_PACKAGES="\
     python3 \
-    openjdk8 \
+    # openjdk8 \
+    "
+
+ENV PDAL_RUNTIME_PACKAGES="\
+    curl \
+    jsoncpp \
+    libexecinfo \
+    libunwind \
+    gdal \
+    geos \
+    libxml2 \
+    postgresql \
+    python3 \
+    py3-numpy sqlite \
     "
 
 # Keep basic packages for simple debugging
 ENV GRASS_RUNTIME_BASIC_PACKAGES="gdal python3 zstd-libs"
-ENV GRASS_RUNTIME_ALPINE_TESTING_REPO_PACKAGES="pdal"
 ENV GRASS_RUNTIME_PACKAGES="\
     cairo \
     fftw \
@@ -51,13 +63,31 @@ ENV ACTINIA_PLUGIN_INSTALL_PACKAGES="\
 
 RUN apk update; \
     apk add --no-cache \
-        --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-        $GRASS_RUNTIME_ALPINE_TESTING_REPO_PACKAGES; \
-    apk add --no-cache \
         $SNAPPY_RUNTIME_PACKAGES \
+        $PDAL_RUNTIME_PACKAGES \
         $GRASS_RUNTIME_PACKAGES \
         $GRASS_ADDONS_BUILD_PACKAGES \
         $ACTINIA_PLUGIN_INSTALL_PACKAGES
+
+COPY --from=pdal /usr/bin/pdal* /usr/bin/
+COPY --from=pdal /usr/lib/pdal /usr/lib/pdal
+COPY --from=pdal /usr/lib/libpdal* /usr/lib/
+COPY --from=pdal /usr/lib/pkgconfig/pdal.pc /usr/lib/pkgconfig/pdal.pc
+COPY --from=pdal /usr/include/pdal /usr/include/pdal
+COPY --from=pdal /usr/local/lib/liblaszip* /usr/local/lib/
+COPY --from=pdal /usr/local/include/laszip /usr/local/include/laszip
+
+ARG OPENJDK_VERSION=8.232.09-r0
+ARG OPENJDK_PKGS_URL=https://github.com/mmacata/alpine-openjdk8/releases/download/$OPENJDK_VERSION
+RUN curl -L $OPENJDK_PKGS_URL/openjdk8-$OPENJDK_VERSION.apk > openjdk8-$OPENJDK_VERSION.apk
+RUN curl -L $OPENJDK_PKGS_URL/openjdk8-jre-$OPENJDK_VERSION.apk > openjdk8-jre-$OPENJDK_VERSION.apk
+RUN curl -L $OPENJDK_PKGS_URL/openjdk8-jre-base-$OPENJDK_VERSION.apk > openjdk8-jre-base-$OPENJDK_VERSION.apk
+RUN curl -L $OPENJDK_PKGS_URL/openjdk8-jre-lib-$OPENJDK_VERSION.apk > openjdk8-jre-lib-$OPENJDK_VERSION.apk
+RUN apk add --allow-untrusted \
+    openjdk8-jre-lib-$OPENJDK_VERSION.apk \
+    openjdk8-$OPENJDK_VERSION.apk \
+    openjdk8-jre-base-$OPENJDK_VERSION.apk \
+    openjdk8-jre-$OPENJDK_VERSION.apk
 
 # Duplicated in final images, only here to safe time
 COPY requirements-alpine.txt /src/requirements-alpine.txt

--- a/docker/actinia-core-alpine/README.md
+++ b/docker/actinia-core-alpine/README.md
@@ -10,19 +10,22 @@ __Build with__:
 
 ```bash
 $ docker build \
+        --no-cache \
         --file docker/actinia-core-alpine/Dockerfile_build_pkgs \
         --tag actinia-core:alpine-build-pkgs .
-$ docker tag actinia-core:alpine-build-pkgs mundialis/actinia-core:alpine-build-pkgs
-$ docker push mundialis/actinia-core:alpine-build-pkgs
+$ docker tag actinia-core:alpine-build-pkgs mundialis/actinia-core:alpine-build-pkgs_v2
+$ docker push mundialis/actinia-core:alpine-build-pkgs_v2
 
 $ docker build \
+        --no-cache \
         --file docker/actinia-core-alpine/Dockerfile_runtime_pkgs \
         --tag actinia-core:alpine-runtime-pkgs .
-$ docker tag actinia-core:alpine-runtime-pkgs mundialis/actinia-core:alpine-runtime-pkgs
-$ docker push mundialis/actinia-core:alpine-runtime-pkgs
+$ docker tag actinia-core:alpine-runtime-pkgs mundialis/actinia-core:alpine-runtime-pkgs_v2
+$ docker push mundialis/actinia-core:alpine-runtime-pkgs_v2
 
 $ docker build \
+        --no-cache \
         --file docker/actinia-core-alpine/Dockerfile \
-        --tag actinia-core:stable-alpine-final .
+        --tag actinia-core:g78-stable-alpine .
 
 ```


### PR DESCRIPTION
As alpine:edge leads to uncontrolled package updates which might break things, the use of a stable alpine version as base image is much more stable. Therefore this PR

- uses alpine:3.11 as base image for build and runtime images (actinia-core following as soon as other images from which it depends have switched as well)
- uses compiled PDAL and LASZIP because they do not exist as alpine:3.11 packages
- gets rid of unstable edge-testing package repository
- uses openjdk8-232 for snappy