### PR TITLE
use s1 toolbox from snappy only

### DIFF
--- a/docker/actinia-core-alpine/Dockerfile
+++ b/docker/actinia-core-alpine/Dockerfile
@@ -1,5 +1,5 @@
 FROM mundialis/grass-py3-pdal:stable-alpine as grass
-FROM mundialis/esa-snap:7.0v1 as snap
+FROM mundialis/esa-snap:s1tbx-7.0v1 as snap
 FROM mundialis/actinia-core:alpine-build-pkgs_v2 as build
 
 LABEL authors="Carmen Tawalika,Anika Bettge,Markus Neteler,Sören Gebbert"


### PR DESCRIPTION
In alpine Dockerfile, the use of S2 and S3 Toolboxes from esa snap brings a duplicate (and old) GDAL and openjpeg. This breaks things. As we only use S1 Toolbox, this PR uses a different esa-snap Dockerimage for multistage which has only s1tbx installed.