### PR TITLE
docker: alpine version 3.12

### DIFF
--- a/docker/actinia-core-alpine/Dockerfile
+++ b/docker/actinia-core-alpine/Dockerfile
@@ -74,6 +74,7 @@ COPY --from=build /build/*.whl /build/
 # RUN apk add curl && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py pip==20.0.2 && rm get-pip.py
 RUN pip3 install /build/*
 # See in build stage why we need this here
+# TODO: replace edge testing packages as soon as possible.
 RUN apk add --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing py3-scikit-learn
 
 # Duplicate install actinia_core requirements. They are already wheels in

--- a/docker/actinia-core-alpine/Dockerfile
+++ b/docker/actinia-core-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM mundialis/grass-py3-pdal:stable-alpine as grass
 FROM mundialis/esa-snap:s1tbx-7.0v2 as snap
-FROM mundialis/actinia-core:alpine-build-pkgs_v2 as build
+FROM mundialis/actinia-core:alpine-build-pkgs_v3 as build
 
 LABEL authors="Carmen Tawalika,Anika Bettge,Markus Neteler,Sören Gebbert"
 LABEL maintainer="tawalika@mundialis.de,bettge@mundialis.de,neteler@mundialis.de,soerengebbert@gmail.com"
@@ -18,7 +18,7 @@ RUN python3 setup.py sdist bdist_wheel -d /build
 # RUN python3 -m pep517.build --out-dir /build . && \
 
 
-FROM mundialis/actinia-core:alpine-runtime-pkgs_v2 as actinia
+FROM mundialis/actinia-core:alpine-runtime-pkgs_v3 as actinia
 
 ENV LC_ALL "en_US.UTF-8"
 ENV GDAL_CACHEMAX=2000

--- a/docker/actinia-core-alpine/Dockerfile
+++ b/docker/actinia-core-alpine/Dockerfile
@@ -1,5 +1,5 @@
 FROM mundialis/grass-py3-pdal:stable-alpine as grass
-FROM mundialis/esa-snap:s1tbx-7.0v1 as snap
+FROM mundialis/esa-snap:s1tbx-7.0v2 as snap
 FROM mundialis/actinia-core:alpine-build-pkgs_v2 as build
 
 LABEL authors="Carmen Tawalika,Anika Bettge,Markus Neteler,Sören Gebbert"
@@ -74,7 +74,7 @@ COPY --from=build /build/*.whl /build/
 # RUN apk add curl && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py pip==20.0.2 && rm get-pip.py
 RUN pip3 install /build/*
 # See in build stage why we need this here
-RUN pip3 install scikit-learn
+RUN apk add --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing py3-scikit-learn
 
 # Duplicate install actinia_core requirements. They are already wheels in
 # /build folder, keep to check match of required packages

--- a/docker/actinia-core-alpine/Dockerfile_build_pkgs
+++ b/docker/actinia-core-alpine/Dockerfile_build_pkgs
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.12
 
 ENV BUILD_PACKAGES="\
     gcc \

--- a/docker/actinia-core-alpine/Dockerfile_runtime_pkgs
+++ b/docker/actinia-core-alpine/Dockerfile_runtime_pkgs
@@ -1,5 +1,5 @@
 FROM mundialis/docker-pdal:2.1.0 as pdal
-FROM mundialis/actinia-core:alpine-build-pkgs_v2
+FROM mundialis/actinia-core:alpine-build-pkgs_v3
 
 ENV SNAPPY_RUNTIME_PACKAGES="\
     python3 \

--- a/docker/actinia-core-alpine/Dockerfile_runtime_pkgs
+++ b/docker/actinia-core-alpine/Dockerfile_runtime_pkgs
@@ -1,4 +1,4 @@
-FROM mundialis/docker-pdal:1.8.0 as pdal
+FROM mundialis/docker-pdal:2.1.0 as pdal
 FROM mundialis/actinia-core:alpine-build-pkgs_v2
 
 ENV SNAPPY_RUNTIME_PACKAGES="\
@@ -70,7 +70,6 @@ RUN apk update; \
         $ACTINIA_PLUGIN_INSTALL_PACKAGES
 
 COPY --from=pdal /usr/bin/pdal* /usr/bin/
-COPY --from=pdal /usr/lib/pdal /usr/lib/pdal
 COPY --from=pdal /usr/lib/libpdal* /usr/lib/
 COPY --from=pdal /usr/lib/pkgconfig/pdal.pc /usr/lib/pkgconfig/pdal.pc
 COPY --from=pdal /usr/include/pdal /usr/include/pdal

--- a/docker/actinia-core-alpine/README.md
+++ b/docker/actinia-core-alpine/README.md
@@ -10,20 +10,23 @@ __Build with__:
 
 ```bash
 $ docker build \
+        --pull \
         --no-cache \
         --file docker/actinia-core-alpine/Dockerfile_build_pkgs \
         --tag actinia-core:alpine-build-pkgs .
-$ docker tag actinia-core:alpine-build-pkgs mundialis/actinia-core:alpine-build-pkgs_v2
-$ docker push mundialis/actinia-core:alpine-build-pkgs_v2
+$ docker tag actinia-core:alpine-build-pkgs mundialis/actinia-core:alpine-build-pkgs_v3
+$ docker push mundialis/actinia-core:alpine-build-pkgs_v3
 
 $ docker build \
+        --pull \
         --no-cache \
         --file docker/actinia-core-alpine/Dockerfile_runtime_pkgs \
         --tag actinia-core:alpine-runtime-pkgs .
-$ docker tag actinia-core:alpine-runtime-pkgs mundialis/actinia-core:alpine-runtime-pkgs_v2
-$ docker push mundialis/actinia-core:alpine-runtime-pkgs_v2
+$ docker tag actinia-core:alpine-runtime-pkgs mundialis/actinia-core:alpine-runtime-pkgs_v3
+$ docker push mundialis/actinia-core:alpine-runtime-pkgs_v3
 
 $ docker build \
+        --pull \
         --no-cache \
         --file docker/actinia-core-alpine/Dockerfile \
         --tag actinia-core:g78-stable-alpine .

--- a/requirements-alpine.txt
+++ b/requirements-alpine.txt
@@ -13,12 +13,14 @@ google-cloud>=0.32.0
 google-cloud-bigquery>=0.28.0
 google-cloud-storage>=1.6.0
 gunicorn>=19.9.0
+joblib==0.15.1
 passlib>=1.7.1
 ply>=3.11
 python-json-logger
 python-magic>=0.4.15
-scikit-learn
+# scikit-learn
 Sphinx>=1.7.1
+threadpoolctl==2.1.0
 redis>=2.10.6
 requests>=2.20.0
 rq>=0.10.0
@@ -43,3 +45,5 @@ wheel
 # Sphinx-2.2.2
 # redis-3.3.11
 # rq-1.1.0
+
+# TODO: remove threadpoolctl and if not needed anymore for scikit-learn

--- a/requirements-alpine.txt
+++ b/requirements-alpine.txt
@@ -1,7 +1,7 @@
 # Python3 requirements for actinia core and GRASS GIS
 
 boto3>=1.6.6
-docutils>=0.14
+docutils==0.15
 Flask>=0.12.3
 Flask-HTTPAuth>=3.2.3
 Flask-RESTful>=0.3.6


### PR DESCRIPTION
There is a new alpine version 3.12 (https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases).
Depends on mundialis/esa-snap:s1tbx-7.0v2 (https://hub.docker.com/r/mundialis/esa-snap/tags) and on grass-py3-pdal:stable-alpine (https://hub.docker.com/repository/docker/mundialis/grass-py3-pdal/builds)

