### PR TITLE
add psutil to get the used/total memory

### DIFF
--- a/requirements-alpine.txt
+++ b/requirements-alpine.txt
@@ -16,6 +16,7 @@ gunicorn>=19.9.0
 joblib==0.15.1
 passlib>=1.7.1
 ply>=3.11
+psutil==5.7.0
 python-json-logger
 python-magic>=0.4.15
 # scikit-learn


### PR DESCRIPTION
For alpine 3.12 `free -m -t` does not work anymore. With python3 and psutil you can get the same information. Cause of that psutil is added to the requirements-alpine.txt.