### PR TITLE
Fix: groups

### DIFF
--- a/src/actinia_core/resources/persistent_processing.py
+++ b/src/actinia_core/resources/persistent_processing.py
@@ -405,7 +405,7 @@ class PersistentProcessing(EphemeralProcessing):
         directories = ["cell", "misc", "fcell",
                        "cats", "cellhd",
                        "cell_misc", "colr", "colr2",
-                       "hist", "vector"]
+                       "hist", "vector", "group"]
 
         for directory in directories:
             source_path = os.path.join(self.user_location_path, source_mapset, directory)


### PR DESCRIPTION
In the moment a group is not copied to the target mapset, if the mapset allready exists.
This change adds group to copied directories.