### PR TITLE
add colorlog and psutil to ubuntu19 requirements

### DIFF
--- a/requirements_ubuntu19.txt
+++ b/requirements_ubuntu19.txt
@@ -1,6 +1,7 @@
 # Python3 requirements for actinia core and GRASS GIS latest
 
 boto3>=1.6.6
+colorlog
 docutils>=0.14
 Flask>=0.12.3
 Flask-HTTPAuth>=3.2.3

--- a/requirements_ubuntu19.txt
+++ b/requirements_ubuntu19.txt
@@ -1,7 +1,7 @@
 # Python3 requirements for actinia core and GRASS GIS latest
 
 boto3>=1.6.6
-colorlog
+colorlog>=4.2.1
 docutils>=0.14
 Flask>=0.12.3
 Flask-HTTPAuth>=3.2.3
@@ -18,6 +18,7 @@ numpy>=1.15.4
 pandas
 passlib>=1.7.1
 ply>=3.11
+psutil>=5.7.0
 pyproj>=2.2.0
 python-json-logger
 python-magic>=0.4.15


### PR DESCRIPTION
colorlog is required for correct logging in ubuntu19