### PR TITLE
PEP8: fix E225 missing whitespace around operator

### DIFF
--- a/src/actinia_core/resources/common/app.py
+++ b/src/actinia_core/resources/common/app.py
@@ -25,7 +25,7 @@
 App configuration of flask, flask_restful, redis server connection
 and global settings
 """
-actinia_string="""Actinia"""
+actinia_string = """Actinia"""
 
 actinia_description = """
 ================================
@@ -96,10 +96,10 @@ __copyright__ = "Copyright 2016-2018, Sören Gebbert and mundialis GmbH & Co. KG
 __maintainer__ = "Sören Gebbert"
 __email__ = "soerengebbert@googlemail.com"
 
-API_VERSION="v1"
+API_VERSION = "v1"
 
 # This is the URL prefix that must be used in the tests
-URL_PREFIX="/api/%s" %API_VERSION
+URL_PREFIX = "/api/%s" % API_VERSION
 
 
 flask_app = Flask(__name__)
@@ -114,6 +114,6 @@ flask_api = Api(flask_app, prefix=URL_PREFIX,
 
 # Set the security definition in an unconventional way
 flask_api._swagger_object["securityDefinitions"] = {"basicAuth":{"type": "basic"}}
-flask_api._swagger_object["security"]=[{"basicAuth":[]}]
+flask_api._swagger_object["security"] = [{"basicAuth":[]}]
 
 auth = HTTPBasicAuth()

--- a/src/actinia_core/resources/common/aws_sentinel_interface.py
+++ b/src/actinia_core/resources/common/aws_sentinel_interface.py
@@ -109,7 +109,7 @@ class AWSSentinel2AInterface(object):
 
             for band in bands:
                 if band not in self.sentinel_bands:
-                    raise Exception("Unknown Sentinel-2 band name <%s>" %band)
+                    raise Exception("Unknown Sentinel-2 band name <%s>" % band)
 
             result = []
 
@@ -133,7 +133,7 @@ class AWSSentinel2AInterface(object):
                 # Get the product info JSON file
 
                 json_url = "%(base)s/products/%(year)s/%(month)s/%(day)s/%(id)s/" \
-                           "productInfo.json" %{"base":self.aws_sentinel_base_url,
+                           "productInfo.json" % {"base":self.aws_sentinel_base_url,
                                                "year":year,
                                                "month":month,
                                                "day":day,
@@ -146,7 +146,7 @@ class AWSSentinel2AInterface(object):
                 try:
                     info = json_loads(product_info)
                 except:
-                    raise Exception("Unable to read the productInfo.json file from URL: %s. Error: %s" %(json_url,
+                    raise Exception("Unable to read the productInfo.json file from URL: %s. Error: %s" % (json_url,
                                                                                                         product_info))
 
                 if info:
@@ -177,13 +177,13 @@ class AWSSentinel2AInterface(object):
                         public_url = self.aws_sentinel_base_url + "/" + tile["path"]
 
                         for band in bands:
-                            tile_name = "%s_tile_%i_band_%s.jp2" %(product_id, tile_num, band)
-                            map_name = "%s_tile_%i_band_%s" %(product_id, tile_num, band)
+                            tile_name = "%s_tile_%i_band_%s.jp2" % (product_id, tile_num, band)
+                            map_name = "%s_tile_%i_band_%s" % (product_id, tile_num, band)
 
                             tile_info[band] = {}
                             tile_info[band]["file_name"] = tile_name
                             tile_info[band]["map_name"] = map_name
-                            tile_info[band]["public_url"] = "%s/%s.jp2" %(public_url, band)
+                            tile_info[band]["public_url"] = "%s/%s.jp2" % (public_url, band)
 
                         scene_entry["tiles"].append(tile_info)
 
@@ -211,6 +211,6 @@ class AWSSentinel2AInterface(object):
         try:
             info = json_loads(tile_info)
         except:
-            raise Exception("Unable to read the info json file from URL: %s. Error: %s" %(tile_entry["info"],
+            raise Exception("Unable to read the info json file from URL: %s. Error: %s" % (tile_entry["info"],
                                                                                          tile_info))
         return json_dumps(info["tileDataGeometry"])

--- a/src/actinia_core/resources/common/exceptions.py
+++ b/src/actinia_core/resources/common/exceptions.py
@@ -37,7 +37,7 @@ class AsyncProcessError(Exception):
     """Raise this exception in case the asynchronous processing faces an error
     """
     def __init__(self, message):
-        message = "%s:  %s" %(str(self.__class__.__name__), message)
+        message = "%s:  %s" % (str(self.__class__.__name__), message)
         Exception.__init__(self, message)
 
 
@@ -45,7 +45,7 @@ class AsyncProcessTermination(Exception):
     """Raise this exception in case the termination requests was executed successfully
     """
     def __init__(self, message):
-        message = "%s:  %s" %(str(self.__class__.__name__), message)
+        message = "%s:  %s" % (str(self.__class__.__name__), message)
         Exception.__init__(self, message)
 
 
@@ -53,7 +53,7 @@ class AsyncProcessTimeLimit(Exception):
     """Raise this exception in case the process time limit was reached
     """
     def __init__(self, message):
-        message = "%s:  %s" %(str(self.__class__.__name__), message)
+        message = "%s:  %s" % (str(self.__class__.__name__), message)
         Exception.__init__(self, message)
 
 
@@ -62,5 +62,5 @@ class GoogleCloudAPIError(Exception):
     when accessing the google API
     """
     def __init__(self, message):
-        message = "%s:  %s" %(str(self.__class__.__name__), message)
+        message = "%s:  %s" % (str(self.__class__.__name__), message)
         Exception.__init__(self, message)

--- a/src/actinia_core/resources/common/google_satellite_bigquery_interface.py
+++ b/src/actinia_core/resources/common/google_satellite_bigquery_interface.py
@@ -63,7 +63,7 @@ def extract_sensor_id_from_scene_id(scene_id):
         The sencor id
 
     """
-    return "%s0%s" %(scene_id[0:2], scene_id[2:3])
+    return "%s0%s" % (scene_id[0:2], scene_id[2:3])
 
 
 class GoogleSatelliteBigQueryInterface(object):
@@ -182,11 +182,11 @@ class GoogleSatelliteBigQueryInterface(object):
                         "FROM `bigquery-public-data.cloud_storage_geo_index.landsat_index` "
 
                 if scene_id:
-                    scene_id_query = "scene_id = \'%s\'" %scene_id
+                    scene_id_query = "scene_id = \'%s\'" % scene_id
                     has_where_statement = True
 
                 if spacecraft_id:
-                    spacecraft_id_query = "spacecraft_id = \'%s\'" %spacecraft_id
+                    spacecraft_id_query = "spacecraft_id = \'%s\'" % spacecraft_id
                     has_where_statement = True
 
             else:
@@ -195,60 +195,60 @@ class GoogleSatelliteBigQueryInterface(object):
                         "FROM `bigquery-public-data.cloud_storage_geo_index.sentinel_2_index` " \
 
                 if scene_id:
-                    scene_id_query = "product_id = \'%s\'" %scene_id
+                    scene_id_query = "product_id = \'%s\'" % scene_id
                     has_where_statement = True
 
             if start_time and end_time:
                 start_time = dtparser.parse(start_time)
                 end_time = dtparser.parse(end_time)
                 temporal_query = "sensing_time >= \'%(start)s\' " \
-                                 "AND sensing_time <= \'%(end)s\'" %{"start": start_time.isoformat(),
+                                 "AND sensing_time <= \'%(end)s\'" % {"start": start_time.isoformat(),
                                                                     "end": end_time.isoformat()}
                 has_where_statement = True
 
             if lon and lat:
                 spatial_query = "west_lon <= %(lon)f AND east_lon >= %(lon)f AND " \
-                                "north_lat >= %(lat)f AND south_lat <= %(lat)f" %{"lon": float(lon),
+                                "north_lat >= %(lat)f AND south_lat <= %(lat)f" % {"lon": float(lon),
                                                                                  "lat": float(lat)}
                 has_where_statement = True
 
             if cloud_cover:
-                cloud_cover_query = "cloud_cover <= %s" %str(cloud_cover)
+                cloud_cover_query = "cloud_cover <= %s" % str(cloud_cover)
                 has_where_statement = True
 
             if has_where_statement is True:
                 query += " WHERE "
 
             if scene_id_query:
-                query += " (%s) " %scene_id_query
+                query += " (%s) " % scene_id_query
                 statement_count += 1
 
             if spacecraft_id_query:
                 if statement_count > 0:
-                    query += " AND (%s) " %spacecraft_id_query
+                    query += " AND (%s) " % spacecraft_id_query
                 else:
-                    query += " (%s) " %spacecraft_id_query
+                    query += " (%s) " % spacecraft_id_query
                 statement_count += 1
 
             if temporal_query:
                 if statement_count > 0:
-                    query += " AND (%s) " %temporal_query
+                    query += " AND (%s) " % temporal_query
                 else:
-                    query += " (%s) " %temporal_query
+                    query += " (%s) " % temporal_query
                 statement_count += 1
 
             if spatial_query:
                 if statement_count > 0:
-                    query += " AND (%s) " %spatial_query
+                    query += " AND (%s) " % spatial_query
                 else:
-                    query += " (%s) " %spatial_query
+                    query += " (%s) " % spatial_query
                 statement_count += 1
 
             if cloud_cover_query:
                 if statement_count > 0:
-                    query += " AND (%s) " %cloud_cover_query
+                    query += " AND (%s) " % cloud_cover_query
                 else:
-                    query += " (%s) " %cloud_cover_query
+                    query += " (%s) " % cloud_cover_query
                 statement_count += 1
 
             query_results = self.bigquery_client.query(query)
@@ -266,7 +266,7 @@ class GoogleSatelliteBigQueryInterface(object):
 
         except Exception as e:
             raise GoogleCloudAPIError("An error occurred while querying "
-                                      "google archive. Error message: %s" %str(e))
+                                      "google archive. Error message: %s" % str(e))
 
     def get_landsat_urls(self, scene_ids, bands=["B1", "B2"]):
         """Receive the Google Cloud Storage (GCS) download urls and time stamps for a list of Landsat scene ids
@@ -342,12 +342,12 @@ class GoogleSatelliteBigQueryInterface(object):
                 sensor_id = extract_sensor_id_from_scene_id(scene_id)
                 for band in bands:
                     if band not in self.landsat_scene_bands[sensor_id]:
-                        raise Exception("Unknown landsat band name <%s>" %band)
+                        raise Exception("Unknown landsat band name <%s>" % band)
 
             # Select specific columns from the sentinel table
             query = "SELECT scene_id,sensing_time,base_url " \
                     "FROM `bigquery-public-data.cloud_storage_geo_index.landsat_index` " \
-                    "WHERE scene_id IN (\"%s\");" %"\",\"".join(scene_ids)
+                    "WHERE scene_id IN (\"%s\");" % "\",\"".join(scene_ids)
 
             query_results = self.bigquery_client.query(query)
             result = {}
@@ -367,12 +367,12 @@ class GoogleSatelliteBigQueryInterface(object):
                         if band == "MTL":
                             suffix = "txt"
 
-                        file_name = "%s_%s.%s" %(scene_id, band, suffix)
-                        map_name = "%s_%s" %(scene_id, band)
+                        file_name = "%s_%s.%s" % (scene_id, band, suffix)
+                        map_name = "%s_%s" % (scene_id, band)
                         if band != "MTL":
                             index = self.landsat_scene_bands[sensor_id].index(band)
                             raster_suffix = self.raster_suffixes[sensor_id][index]
-                            map_name = "%s%s" %(scene_id, raster_suffix)
+                            map_name = "%s%s" % (scene_id, raster_suffix)
 
                         result[scene_id][band] = {}
                         result[scene_id][band]["file"] = file_name
@@ -384,7 +384,7 @@ class GoogleSatelliteBigQueryInterface(object):
 
         except Exception as e:
             raise GoogleCloudAPIError("An error occurred while fetching "
-                                      "Landsat download URL's. Error message: %s" %str(e))
+                                      "Landsat download URL's. Error message: %s" % str(e))
 
     def get_sentinel_urls(self, product_ids, bands=["B04","B08"]):
         """Receive the download urls and time stamps for a list of Sentinel2 product ids from Google Big Query service
@@ -459,12 +459,12 @@ class GoogleSatelliteBigQueryInterface(object):
 
             for band in bands:
                 if band not in self.sentinel_bands:
-                    raise Exception("Unknown Sentinel-2 band name <%s>" %band)
+                    raise Exception("Unknown Sentinel-2 band name <%s>" % band)
 
             # Select specific columns from the sentinel table
             query = "SELECT granule_id,product_id,sensing_Time,datatake_identifier,base_url " \
                     "FROM `bigquery-public-data.cloud_storage_geo_index.sentinel_2_index` " \
-                    "WHERE product_id IN (\"%s\");" %"\",\"".join(product_ids)
+                    "WHERE product_id IN (\"%s\");" % "\",\"".join(product_ids)
 
             rows = list(self.bigquery_client.query(query))  # API request
 
@@ -492,8 +492,8 @@ class GoogleSatelliteBigQueryInterface(object):
                     # result[product_id]["xml_metadata"] = xml_metadata
 
                     for band in bands:
-                        tile_name = "%s_%s.jp2" %(tile_base_name, band)
-                        map_name = "%s_%s" %(product_id, band)
+                        tile_name = "%s_%s.jp2" % (tile_base_name, band)
+                        map_name = "%s_%s" % (product_id, band)
 
                         result[product_id][band] = {}
                         result[product_id][band]["tile"] = tile_name
@@ -505,7 +505,7 @@ class GoogleSatelliteBigQueryInterface(object):
 
         except Exception as e:
             raise GoogleCloudAPIError("An error occurred while fetching "
-                                      "Sentinel-2 download URL's. Error message: %s" %str(e))
+                                      "Sentinel-2 download URL's. Error message: %s" % str(e))
 
     def _generate_sentinel2_footprint(self, base_url):
         """Download the sentinel XML metadata and parse it for the footpring
@@ -557,6 +557,6 @@ class GoogleSatelliteBigQueryInterface(object):
             if float(x) < min_x:
                 min_x = float(x)
             i += 1
-            gml_coord_list.append("%s,%s" %(x, y))
+            gml_coord_list.append("%s,%s" % (x, y))
 
-        return GML_BODY %" ".join(gml_coord_list), xml_content, (min_x, max_y, max_x, min_y)
+        return GML_BODY % " ".join(gml_coord_list), xml_content, (min_x, max_y, max_x, min_y)

--- a/src/actinia_core/resources/common/grass_init.py
+++ b/src/actinia_core/resources/common/grass_init.py
@@ -45,7 +45,7 @@ class GrassInitError(Exception):
     initialization error of the GRASS environment
     """
     def __init__(self, message):
-        message = "%s:  %s" %(str(self.__class__.__name__), message)
+        message = "%s:  %s" % (str(self.__class__.__name__), message)
         Exception.__init__(self, message)
         logger = MessageLogger()
         logger.error(message)
@@ -132,7 +132,7 @@ class GrassEnvironment(ProcessLogging):
             try:
                 self.env[key] = os.getenv(key, self.env[key])
             except Exception as e:
-                raise GrassInitError("Error getting grass environmental variables. Exception: %s" %str(e))
+                raise GrassInitError("Error getting grass environmental variables. Exception: %s" % str(e))
 
     def set(self):
         for key in self.env:
@@ -145,7 +145,7 @@ class GrassEnvironment(ProcessLogging):
                 os.environ[key] = value
                 self.log_debug(key + "=" + value)
             except Exception as e:
-                raise GrassInitError("Error setting grass environmental variables. Exception: %s" %str(e))
+                raise GrassInitError("Error setting grass environmental variables. Exception: %s" % str(e))
 
 
 class GrassGisRC(ProcessLogging):
@@ -323,22 +323,22 @@ class GrassModuleRunner(ProcessLogging):
         # Search the module in the bin directory
         grass_module_path = os.path.join(self.grassbase, "bin", grass_module)
         pathList.append(grass_module_path)
-        self.log_debug("Looking for %s" %grass_module_path)
+        self.log_debug("Looking for %s" % grass_module_path)
 
         if os.path.isfile(grass_module_path) is not True:
             grass_module_path = os.path.join(self.grassbase, "scripts", grass_module)
             pathList.append(grass_module_path)
-            self.log_debug("Looking for %s" %grass_module_path)
+            self.log_debug("Looking for %s" % grass_module_path)
             # if the module was not found in the bin dir, test the script directory
             if os.path.isfile(grass_module_path) is not True:
                 grass_module_path = os.path.join(self.grass_addon_path, "bin", grass_module)
                 pathList.append(grass_module_path)
-                self.log_debug("Looking for %s" %grass_module_path)
+                self.log_debug("Looking for %s" % grass_module_path)
                 # if the module was not found in the script dir, test the addon path
                 if os.path.isfile(grass_module_path) is not True:
                     grass_module_path = os.path.join(self.grass_addon_path, "scripts", grass_module)
                     pathList.append(grass_module_path)
-                    self.log_debug("Looking for %s" %grass_module_path)
+                    self.log_debug("Looking for %s" % grass_module_path)
                     if os.path.isfile(grass_module_path) is not True:
                         raise GrassInitError("GRASS module " + grass_module + " not found in " + str(pathList))
 
@@ -482,7 +482,7 @@ class GrassInitializer(ProcessLogging):
             shutil.rmtree(self.gisrc_path)
         else:
             logger = MessageLogger()
-            logger.error("Unable to delete temporary grass database <%s>" %self.gisrc_path)
+            logger.error("Unable to delete temporary grass database <%s>" % self.gisrc_path)
 
     def setup_tmp_region(self):
         """Setup a temporary region, so that g.region calls can be performed without
@@ -496,7 +496,7 @@ class GrassInitializer(ProcessLogging):
 
         """
         # Safe the current region in a temporary region that can be overwritten
-        errorid, stdout_buff, stderr_buff = self.run_module("g.region", ["save=%s" %self.tmp_region_name, "--o"])
+        errorid, stdout_buff, stderr_buff = self.run_module("g.region", ["save=%s" % self.tmp_region_name, "--o"])
 
         if errorid != 0:
             raise GrassInitError("Unable to create a temporary region")
@@ -516,9 +516,9 @@ class GrassInitializer(ProcessLogging):
             try:
                 if "WIND_OVERRIDE" in os.environ:
                     os.environ.pop("WIND_OVERRIDE")
-                    self.run_module("g.remove", ["name=%s" %self.tmp_region_name, "type=region", "-f"])
+                    self.run_module("g.remove", ["name=%s" % self.tmp_region_name, "type=region", "-f"])
             except Exception as e:
                 logger = MessageLogger()
-                logger.error("Unable to delete temporary region <%s>" %self.tmp_region_name)
+                logger.error("Unable to delete temporary region <%s>" % self.tmp_region_name)
 
             self.has_temp_region = False

--- a/src/actinia_core/resources/common/landsat_processing_library.py
+++ b/src/actinia_core/resources/common/landsat_processing_library.py
@@ -34,9 +34,9 @@ __copyright__ = "Copyright 2016-2018, Sören Gebbert and mundialis GmbH & Co. KG
 __maintainer__ = "Sören Gebbert"
 __email__ = "soerengebbert@googlemail.com"
 
-SUPPORTED_MIMETYPES=["application/zip", "application/tiff", "application/gml"]
+SUPPORTED_MIMETYPES = ["application/zip", "application/tiff", "application/gml"]
 
-SCENE_SUFFIXES={
+SCENE_SUFFIXES = {
 "LT04":["_B1.TIF", "_B2.TIF", "_B3.TIF", "_B4.TIF", "_B5.TIF", "_B6.TIF", "_B7.TIF", "_MTL.txt"],
 "LT05":["_B1.TIF", "_B2.TIF", "_B3.TIF", "_B4.TIF", "_B5.TIF", "_B6.TIF", "_B7.TIF", "_MTL.txt"],
 "LE07":["_B1.TIF", "_B2.TIF", "_B3.TIF", "_B4.TIF", "_B5.TIF", "_B6_VCID_2.TIF", "_B6_VCID_1.TIF",
@@ -44,14 +44,14 @@ SCENE_SUFFIXES={
 "LC08":["_B1.TIF", "_B2.TIF", "_B3.TIF", "_B4.TIF", "_B5.TIF", "_B6.TIF", "_B7.TIF",
         "_B8.TIF", "_B9.TIF", "_B10.TIF", "_B11.TIF","_MTL.txt"]}
 
-RASTER_SUFFIXES={
+RASTER_SUFFIXES = {
 "LT04":[".1", ".2", ".3", ".4", ".5", ".6", ".7"],
 "LT05":[".1", ".2", ".3", ".4", ".5", ".6", ".7"],
 "LE07":[".1", ".2", ".3", ".4", ".5", ".61", ".62", ".7", ".8"],
 "LC08":[".1", ".2", ".3", ".4", ".5", ".6", ".7", ".8", ".9", ".10", ".11"]}
 
 
-SCENE_BANDS={"LT04":["B1", "B2", "B3", "B4", "B5", "B6", "B7","MTL"],
+SCENE_BANDS = {"LT04":["B1", "B2", "B3", "B4", "B5", "B6", "B7","MTL"],
              "LT05":["B1", "B2", "B3", "B4", "B5", "B6", "B7","MTL"],
              "LE07":["B1", "B2", "B3", "B4", "B5", "B6_VCID_2",
                      "B6_VCID_1", "B7", "B8","MTL"],
@@ -70,7 +70,7 @@ def extract_sensor_id_from_scene_id(scene_id):
         The sencor id
 
     """
-    return "%s0%s" %(scene_id[0:2], scene_id[2:3])
+    return "%s0%s" % (scene_id[0:2], scene_id[2:3])
 
 
 def scene_id_to_google_url(scene_id,suffix):
@@ -91,7 +91,7 @@ def scene_id_to_google_url(scene_id,suffix):
     path = scene_id[3:6]
     row = scene_id[6:9]
 
-    url = "https://storage.googleapis.com/gcp-public-data-landsat/%s/PRE/%s/%s/%s/%s%s" %(landsat_sensor_id,
+    url = "https://storage.googleapis.com/gcp-public-data-landsat/%s/PRE/%s/%s/%s/%s%s" % (landsat_sensor_id,
                                                                                          path, row,
                                                                                          scene_id,
                                                                                          scene_id,
@@ -176,7 +176,7 @@ class LandsatProcessing(GeoDataDownloadImportSupport):
         count = 0
         # Create file names, urls and check the download cache
         for suffix in SCENE_SUFFIXES[self.landsat_sensor_id]:
-            file_name = "%s%s" %(self.scene_id, suffix)
+            file_name = "%s%s" % (self.scene_id, suffix)
             # This is the file path in the download cache directory
             file_path = os.path.join(self.user_download_cache_path, file_name)
             self.file_list.append(file_path)
@@ -196,7 +196,7 @@ class LandsatProcessing(GeoDataDownloadImportSupport):
 
         for file_path in self.file_list:
             if "_MTL.TXT" not in file_path.upper():
-                raster_name = "%s%s" %(self.scene_id, RASTER_SUFFIXES[self.landsat_sensor_id][count])
+                raster_name = "%s%s" % (self.scene_id, RASTER_SUFFIXES[self.landsat_sensor_id][count])
                 self.raster_names.append(raster_name)
                 self.band_raster_names[SCENE_BANDS[self.landsat_sensor_id][count]] = raster_name
                 p = self.get_raster_import_command(file_path=file_path,
@@ -219,12 +219,12 @@ class LandsatProcessing(GeoDataDownloadImportSupport):
         toar_commands = []
 
         p = Process(exec_type="grass", executable="i.landsat.toar",
-                         executable_params=["input=%s." %self.scene_id,
-                                            "metfile=%s_%s" %(os.path.join(self.user_download_cache_path,
+                         executable_params=["input=%s." % self.scene_id,
+                                            "metfile=%s_%s" % (os.path.join(self.user_download_cache_path,
                                                                           self.scene_id),
                                                              "MTL.txt"),
-                                            "method=%s" %option,
-                                            "output=%s_%s." %(self.scene_id, atcor_method),
+                                            "method=%s" % option,
+                                            "output=%s_%s." % (self.scene_id, atcor_method),
                                             "--q"],
                          skip_permission_check=True)
         toar_commands.append(p)
@@ -232,36 +232,36 @@ class LandsatProcessing(GeoDataDownloadImportSupport):
 
     def get_i_vi_process_list(self, atcor_method, processing_method):
 
-        self.ndvi_name = "%s_%s_%s" %(self.scene_id, atcor_method, processing_method)
+        self.ndvi_name = "%s_%s_%s" % (self.scene_id, atcor_method, processing_method)
 
         ndvi_commands = []
 
         ivi = "i.vi"
         ivi_params = list()
         if self.landsat_sensor_id == "LC08":
-            ivi_params.append("red=%s_%s%s" %(self.scene_id, atcor_method, ".4"))
-            ivi_params.append("nir=%s_%s%s" %(self.scene_id, atcor_method, ".5"))
-            ivi_params.append("green=%s_%s%s" %(self.scene_id, atcor_method, ".3"))
-            ivi_params.append("blue=%s_%s%s" %(self.scene_id, atcor_method, ".2"))
-            ivi_params.append("band5=%s_%s%s" %(self.scene_id, atcor_method, ".7"))
-            ivi_params.append("band7=%s_%s%s" %(self.scene_id, atcor_method, ".8"))
+            ivi_params.append("red=%s_%s%s" % (self.scene_id, atcor_method, ".4"))
+            ivi_params.append("nir=%s_%s%s" % (self.scene_id, atcor_method, ".5"))
+            ivi_params.append("green=%s_%s%s" % (self.scene_id, atcor_method, ".3"))
+            ivi_params.append("blue=%s_%s%s" % (self.scene_id, atcor_method, ".2"))
+            ivi_params.append("band5=%s_%s%s" % (self.scene_id, atcor_method, ".7"))
+            ivi_params.append("band7=%s_%s%s" % (self.scene_id, atcor_method, ".8"))
         else:
-            ivi_params.append("red=%s_%s%s" %(self.scene_id, atcor_method, ".3"))
-            ivi_params.append("nir=%s_%s%s" %(self.scene_id, atcor_method, ".4"))
-            ivi_params.append("green=%s_%s%s" %(self.scene_id, atcor_method, ".2"))
-            ivi_params.append("blue=%s_%s%s" %(self.scene_id, atcor_method, ".1"))
-            ivi_params.append("band5=%s_%s%s" %(self.scene_id, atcor_method, ".5"))
-            ivi_params.append("band7=%s_%s%s" %(self.scene_id, atcor_method, ".7"))
+            ivi_params.append("red=%s_%s%s" % (self.scene_id, atcor_method, ".3"))
+            ivi_params.append("nir=%s_%s%s" % (self.scene_id, atcor_method, ".4"))
+            ivi_params.append("green=%s_%s%s" % (self.scene_id, atcor_method, ".2"))
+            ivi_params.append("blue=%s_%s%s" % (self.scene_id, atcor_method, ".1"))
+            ivi_params.append("band5=%s_%s%s" % (self.scene_id, atcor_method, ".5"))
+            ivi_params.append("band7=%s_%s%s" % (self.scene_id, atcor_method, ".7"))
 
-        ivi_params.append("viname=%s" %processing_method.lower())
-        ivi_params.append("output=%s" %self.ndvi_name)
+        ivi_params.append("viname=%s" % processing_method.lower())
+        ivi_params.append("output=%s" % self.ndvi_name)
 
         p = Process(exec_type="grass", executable=ivi, executable_params=ivi_params,
                          skip_permission_check=True)
         ndvi_commands.append(p)
 
         p = Process(exec_type="grass", executable="r.colors",
-                         executable_params=["map=%s" %self.ndvi_name, "color=ndvi"],
+                         executable_params =["map=%s" % self.ndvi_name, "color=ndvi"],
                          skip_permission_check=True)
         ndvi_commands.append(p)
 

--- a/src/actinia_core/resources/common/process_queue.py
+++ b/src/actinia_core/resources/common/process_queue.py
@@ -190,7 +190,7 @@ class EnqueuedProcess(object):
             if self.timeout < diff:
                 self.terminate(status="timeout",
                                message="Processes exceeded timeout (%i) in "
-                                       "waiting queue and was terminated." %self.timeout)
+                                       "waiting queue and was terminated." % self.timeout)
                 return True
 
         return False
@@ -212,7 +212,7 @@ class EnqueuedProcess(object):
                     if response_model["status"] != "error" and \
                             response_model["status"] != "terminated" and \
                             response_model["status"] != "timeout":
-                        message = "The process unexpectedly terminated with exit code %i" %self.process.exitcode
+                        message = "The process unexpectedly terminated with exit code %i" % self.process.exitcode
                         self._send_resource_update(status="error", message=message, response_data=response_data)
 
     def _send_resource_update(self, status, message, response_data=None):

--- a/src/actinia_core/resources/common/redis_lock.py
+++ b/src/actinia_core/resources/common/redis_lock.py
@@ -160,7 +160,7 @@ class RedisLockingInterface(object):
 
         """
 
-        keys=[self.lock_prefix + str(resource_id), expiration]
+        keys = [self.lock_prefix + str(resource_id), expiration]
         #print "Lock", expiration, self.lock_prefix + str(resource_id), str(self)
         return self.call_lock_resource(keys=keys)
 
@@ -180,7 +180,7 @@ class RedisLockingInterface(object):
             1 for success and 0 if unable to extent the lock because resource does not exists
 
         """
-        keys=[self.lock_prefix + str(resource_id), expiration]
+        keys = [self.lock_prefix + str(resource_id), expiration]
         #print "Extend Lock", expiration, self.lock_prefix + str(resource_id), str(self)
         return self.call_extend_resource_lock(keys=keys)
 
@@ -199,7 +199,7 @@ class RedisLockingInterface(object):
             1 for success and 0 if unable to unlock
 
         """
-        keys=[self.lock_prefix + str(resource_id),]
+        keys = [self.lock_prefix + str(resource_id),]
         #print "UnLock", self.lock_prefix + str(resource_id), str(self)
         return self.call_unlock_resource(keys=keys)
 

--- a/src/actinia_core/resources/common/request_parser.py
+++ b/src/actinia_core/resources/common/request_parser.py
@@ -54,11 +54,11 @@ def extract_where_parameters(args):
     """
     options = []
     if "where" in args and args["where"] is not None:
-        options.append("where=%s" %args["where"])
+        options.append("where=%s" % args["where"])
     if "order" in args and args["order"] is not None:
-        options.append("order=%s" %args["order"])
+        options.append("order=%s" % args["order"])
     if "columns" in args and args["columns"] is not None:
-        options.append("columns=%s" %args["columns"])
+        options.append("columns=%s" % args["columns"])
 
     return options
 
@@ -106,7 +106,7 @@ def extract_start_script_parameters(args):
     options = []
     if "epsg" in args:
         options.append("-c")
-        options.append("EPSG:%i" %args["epsg"])
+        options.append("EPSG:%i" % args["epsg"])
 
     return options
 
@@ -134,11 +134,11 @@ def extract_t_create_parameters(args):
     """
     options = []
     if "temporaltype" in args and args["temporaltype"] is not None:
-        options.append("temporaltype=%s" %args["temporaltype"])
+        options.append("temporaltype=%s" % args["temporaltype"])
     if "title" in args and args["title"] is not None:
-        options.append("title=%s" %args["title"])
+        options.append("title=%s" % args["title"])
     if "description" in args and args["description"] is not None:
-        options.append("description=%s" %args["description"])
+        options.append("description=%s" % args["description"])
     options.append("semantictype=mean")
 
     return options
@@ -177,12 +177,12 @@ def extract_t_register_parameters(args):
     """
     options = []
     if "start" in args and args["start"] is not None:
-        options.append("start=%s" %args["start"])
+        options.append("start=%s" % args["start"])
     if "end" in args and args["end"] is not None:
-        options.append("end=%s" %args["end"])
+        options.append("end=%s" % args["end"])
     if "unit" in args and args["unit"] is not None:
-        options.append("unit=%s" %args["unit"])
+        options.append("unit=%s" % args["unit"])
     if "increment" in args and args["increment"] is not None:
-        options.append("increment=%s" %args["increment"])
+        options.append("increment=%s" % args["increment"])
 
     return options

--- a/src/actinia_core/resources/common/sentinel_processing_library.py
+++ b/src/actinia_core/resources/common/sentinel_processing_library.py
@@ -125,15 +125,15 @@ class Sentinel2Processing(object):
             except Exception as e:
                 raise AsyncProcessError("Error in querying Sentinel-2 product <%s> "
                                         "in Google BigQuery Sentinel-2 database. "
-                                        "Error: %s" %(self.product_id, str(e)))
+                                        "Error: %s" % (self.product_id, str(e)))
 
             if not self.query_result:
                 raise AsyncProcessError("Unable to find Sentinel-2 product <%s> "
-                                        "in Google BigQuery Sentinel-2 database" %self.product_id)
+                                        "in Google BigQuery Sentinel-2 database" % self.product_id)
 
         if self.product_id not in self.query_result:
             raise AsyncProcessError("Unable to find Sentinel-2 product <%s> "
-                                    "in Google BigQuery Sentinel-2 database" %self.product_id)
+                                    "in Google BigQuery Sentinel-2 database" % self.product_id)
 
         # Switch into the tempfile directory
         os.chdir(self.temp_file_path)
@@ -185,15 +185,15 @@ class Sentinel2Processing(object):
         # nothing needs to be downloaded and checked.
         for url in url_list:
             # Send a resource update
-            self.send_resource_update(message="Checking access to URL: %s" %url)
+            self.send_resource_update(message="Checking access to URL: %s" % url)
 
             # Check if thr URL exists by investigating the HTTP header
             resp = requests.head(url)
-            self.message_logger.info("%i %s %s" %(resp.status_code, resp.text, resp.headers))
+            self.message_logger.info("%i %s %s" % (resp.status_code, resp.text, resp.headers))
 
             if resp.status_code != 200:
                 raise AsyncProcessError("Scene <%s> is not available. "
-                                        "The URL <%s> can not be accessed." %(self.product_id, url))
+                                        "The URL <%s> can not be accessed." % (self.product_id, url))
 
         return url_list, copy_file_list
 
@@ -214,15 +214,15 @@ class Sentinel2Processing(object):
             except Exception as e:
                 raise AsyncProcessError("Error in querying Sentinel-2 product <%s> "
                                         "in AWS Sentinel-2 database. "
-                                        "Error: %s" %(self.product_id, str(e)))
+                                        "Error: %s" % (self.product_id, str(e)))
 
             if not self.query_result:
                 raise AsyncProcessError("Unable to find Sentinel-2 product <%s> "
-                                        "in AWS Sentinel-2 database" %self.product_id)
+                                        "in AWS Sentinel-2 database" % self.product_id)
 
         if self.product_id not in self.query_result:
             raise AsyncProcessError("Unable to find Sentinel-2 product <%s> "
-                                    "in AWS Sentinel-2 database" %self.product_id)
+                                    "in AWS Sentinel-2 database" % self.product_id)
 
         # Switch into the tempfile directory
         os.chdir(self.temp_file_path)
@@ -274,15 +274,15 @@ class Sentinel2Processing(object):
         # nothing needs to be downloaded and checked.
         for url in url_list:
             # Send a resource update
-            self.send_resource_update(message="Checking access to URL: %s" %url)
+            self.send_resource_update(message="Checking access to URL: %s" % url)
 
             # Check if thr URL exists by investigating the HTTP header
             resp = requests.head(url)
-            self.message_logger.info("%i %s %s" %(resp.status_code, resp.text, resp.headers))
+            self.message_logger.info("%i %s %s" % (resp.status_code, resp.text, resp.headers))
 
             if resp.status_code != 200:
                 raise AsyncProcessError("Scene <%s> is not available. "
-                                        "The URL <%s> can not be accessed." %(self.product_id, url))
+                                        "The URL <%s> can not be accessed." % (self.product_id, url))
 
         return url_list, copy_file_list
 
@@ -371,8 +371,8 @@ class Sentinel2Processing(object):
         import_commands = []
 
         p = Process(exec_type="grass", executable="v.import",
-                         executable_params=["input=%s" %self.gml_cache_file_name,
-                                            "output=%s" %self.product_id,
+                         executable_params=["input=%s" % self.gml_cache_file_name,
+                                            "output=%s" % self.product_id,
                                             "--q"],
                          skip_permission_check=True)
         import_commands.append(p)
@@ -382,8 +382,8 @@ class Sentinel2Processing(object):
 
         # Attach a the time stamp
         p = Process(exec_type="grass", executable="v.timestamp",
-                         executable_params=["map=%s" %self.product_id,
-                                            "date=%s" %timestamp],
+                         executable_params=["map=%s" % self.product_id,
+                                            "date=%s" % timestamp],
                          skip_permission_check=True)
         import_commands.append(p)
 
@@ -401,10 +401,10 @@ class Sentinel2Processing(object):
             gdal_translate_params = list()
             # -projwin ulx uly lrx lry
             gdal_translate_params.append("-projwin")
-            gdal_translate_params.append("%f" %self.bbox[0])
-            gdal_translate_params.append("%f" %self.bbox[1])
-            gdal_translate_params.append("%f" %self.bbox[2])
-            gdal_translate_params.append("%f" %self.bbox[3])
+            gdal_translate_params.append("%f" % self.bbox[0])
+            gdal_translate_params.append("%f" % self.bbox[1])
+            gdal_translate_params.append("%f" % self.bbox[2])
+            gdal_translate_params.append("%f" % self.bbox[3])
             gdal_translate_params.append("-of")
             gdal_translate_params.append("vrt")
             gdal_translate_params.append("-projwin_srs")
@@ -418,38 +418,38 @@ class Sentinel2Processing(object):
             import_commands.append(p)
 
             p = Process(exec_type="grass", executable="r.import",
-                             executable_params=["input=%s" %cropped_input_file,
-                                                "output=%s" %temp_map_name,
+                             executable_params=["input=%s" % cropped_input_file,
+                                                "output=%s" % temp_map_name,
                                                 "--q"],
                              skip_permission_check=True)
             import_commands.append(p)
 
             p = Process(exec_type="grass", executable="g.region",
-                             executable_params=["align=%s" %temp_map_name,
-                                                "vector=%s" %self.product_id,
+                             executable_params=["align=%s" % temp_map_name,
+                                                "vector=%s" % self.product_id,
                                                 "-g"],
                              skip_permission_check=True)
             import_commands.append(p)
 
             p = Process(exec_type="grass", executable="r.mask",
-                             executable_params=["vector=%s" %self.product_id],
+                             executable_params =["vector=%s" % self.product_id],
                              skip_permission_check=True)
             import_commands.append(p)
 
             p = Process(exec_type="grass", executable="r.mapcalc",
-                             executable_params=["expression=%s = float(%s)" %(map_name,
+                             executable_params=["expression=%s = float(%s)" % (map_name,
                                                                              temp_map_name)],
                              skip_permission_check=True)
             import_commands.append(p)
 
             p = Process(exec_type="grass", executable="r.timestamp",
-                             executable_params=["map=%s" %map_name, "date=%s" %timestamp],
+                             executable_params =["map=%s" % map_name, "date=%s" % timestamp],
                              skip_permission_check=True)
             import_commands.append(p)
 
             p = Process(exec_type="grass", executable="g.remove",
                              executable_params=["type=raster",
-                                                "name=%s" %temp_map_name,
+                                                "name=%s" % temp_map_name,
                                                 "-f"],
                              skip_permission_check=True)
             import_commands.append(p)
@@ -481,7 +481,7 @@ class Sentinel2Processing(object):
         p = Process(exec_type="grass",
                          executable="r.mapcalc",
                          executable_params=["expression=%(ndvi)s = (float(%(nir)s) - float(%(red)s))/"
-                                            "(float(%(nir)s) + float(%(red)s))" %{"ndvi":raster_result_name,
+                                            "(float(%(nir)s) + float(%(red)s))" % {"ndvi":raster_result_name,
                                                                                  "nir":nir,
                                                                                  "red":red}],
                         skip_permission_check=True)
@@ -489,7 +489,7 @@ class Sentinel2Processing(object):
 
         p = Process(exec_type="grass",
                          executable="r.colors",
-                         executable_params=["color=ndvi", "map=%s" %raster_result_name],
+                         executable_params =["color=ndvi", "map=%s" % raster_result_name],
                          skip_permission_check=True)
         ndvi_commands.append(p)
 

--- a/src/actinia_core/resources/common/storage_interface_filesystem.py
+++ b/src/actinia_core/resources/common/storage_interface_filesystem.py
@@ -93,11 +93,11 @@ class ResourceStorageFilesystem(ResourceStorageBase):
                     # TODO Add the directory to the scheduler list
                     pass
                 else:
-                    raise IOError("Unable to create resource directory <%s>" %self.resource_export_path)
+                    raise IOError("Unable to create resource directory <%s>" % self.resource_export_path)
             else:
-                raise IOError("Unable to create resource user directory <%s>" %self.user_export_path)
+                raise IOError("Unable to create resource user directory <%s>" % self.user_export_path)
         else:
-            raise IOError("Unable to access the base resource directory <%s>" %self.resource_dir)
+            raise IOError("Unable to access the base resource directory <%s>" % self.resource_dir)
 
         self.dir_created = True
 

--- a/src/actinia_core/resources/common/user.py
+++ b/src/actinia_core/resources/common/user.py
@@ -48,7 +48,7 @@ class ActiniaUserError(Exception):
     """Raise this exception in case a user creation error happens
     """
     def __init__(self, message):
-        message = "%s:  %s" %(str(self.__class__.__name__), message)
+        message = "%s:  %s" % (str(self.__class__.__name__), message)
         Exception.__init__(self, message)
 
 
@@ -156,7 +156,7 @@ class ActiniaUser(object):
                       "guest"]
         """
         if role not in USER_ROLES:
-            raise ActiniaUserError("Unsupported user role <%s> supported are %s" %(role, str(USER_ROLES)))
+            raise ActiniaUserError("Unsupported user role <%s> supported are %s" % (role, str(USER_ROLES)))
         self.user_role = role
 
     def has_guest_role(self):

--- a/src/actinia_core/resources/ephemeral_custom_processing.py
+++ b/src/actinia_core/resources/ephemeral_custom_processing.py
@@ -113,7 +113,7 @@ class EphemeralCustomProcessing(EphemeralProcessing):
                                                    module_name=self.executable)
 
         if resp is not None:
-            raise AsyncProcessError("Executable <%s> is not suported" %self.executable)
+            raise AsyncProcessError("Executable <%s> is not suported" % self.executable)
 
         p = Process(exec_type="exec",
                          executable=self.executable,

--- a/src/actinia_core/resources/ephemeral_processing.py
+++ b/src/actinia_core/resources/ephemeral_processing.py
@@ -440,7 +440,7 @@ class EphemeralProcessing(object):
         # Call the webhook after the final result was send to the database
         try:
             if final is True and self.webhook_finished is not None:
-                self.message_logger.info("Send POST request to finished webhook url: %s" %self.webhook_finished)
+                self.message_logger.info("Send POST request to finished webhook url: %s" % self.webhook_finished)
                 http_code, response_model = pickle.loads(document)
                 if self.webhook_auth:
                     # username is expected to be without colon (':')
@@ -448,9 +448,9 @@ class EphemeralProcessing(object):
                 else:
                     r = requests.post(self.webhook_finished, json=json.dumps(response_model))
                 if r.status_code not in [200, 204]:
-                    raise AsyncProcessError("Unable to access finished webhook URL %s" %self.webhook_finished)
+                    raise AsyncProcessError("Unable to access finished webhook URL %s" % self.webhook_finished)
             elif final is False and self.webhook_update is not None:
-                self.message_logger.info("Send POST request to update webhook url: %s" %self.webhook_update)
+                self.message_logger.info("Send POST request to update webhook url: %s" % self.webhook_update)
                 http_code, response_model = pickle.loads(document)
                 if self.webhook_auth:
                     # username is expected to be without colon (':')
@@ -458,7 +458,7 @@ class EphemeralProcessing(object):
                 else:
                     r = requests.post(self.webhook_update, json=json.dumps(response_model))
                 if r.status_code not in [200, 204]:
-                    raise AsyncProcessError("Unable to access the update webhook URL %s" %self.webhook_update)
+                    raise AsyncProcessError("Unable to access the update webhook URL %s" % self.webhook_update)
         except Exception as e:
             e_type, e_value, e_tb = sys.exc_info()
             model = ExceptionTracebackModel(message=str(e_value),

--- a/src/actinia_core/resources/ephemeral_processing_with_export.py
+++ b/src/actinia_core/resources/ephemeral_processing_with_export.py
@@ -46,7 +46,7 @@ __maintainer__ = "Sören Gebbert"
 __email__ = "soerengebbert@googlemail.com"
 
 
-DESCR="""Execute a user defined process chain in an ephemeral database
+DESCR = """Execute a user defined process chain in an ephemeral database
 and provide the generated resources as downloadable files via URL's. Minimum required user role: user.
 
 The process chain is executed asynchronously. The provided status URL
@@ -69,7 +69,7 @@ in the process chain for export.
 """
 
 
-SCHEMA_DOC={
+SCHEMA_DOC = {
     'tags': ['Processing'],
     'description': DESCR,
     'consumes':['application/json'],
@@ -235,7 +235,7 @@ class EphemeralProcessingWithExport(EphemeralProcessing):
 
             p = Process(exec_type="grass",
                              executable="g.region",
-                             executable_params=["raster=%s" %raster_name, "-g"],
+                             executable_params =["raster=%s" % raster_name, "-g"],
                              stdin_source=None)
 
             self._update_num_of_steps(1)
@@ -247,8 +247,8 @@ class EphemeralProcessingWithExport(EphemeralProcessing):
         # generate overviews with compression:
         os.environ['COMPRESS_OVERVIEW'] = "LZW"
         module_name = "r.out.gdal"
-        args = ["-fmt", "input=%s" %raster_name, "format=%s" %format,
-                "createopt=COMPRESS=LZW,TILED=YES", "overviews=5", "output=%s" %output_path]
+        args = ["-fmt", "input=%s" % raster_name, "format=%s" % format,
+                "createopt=COMPRESS=LZW,TILED=YES", "overviews=5", "output=%s" % output_path]
 
         if additional_options:
             args.extend(additional_options)
@@ -307,8 +307,8 @@ class EphemeralProcessingWithExport(EphemeralProcessing):
         os.chdir(self.temp_file_path)
 
         module_name = "v.out.ogr"
-        args = ["-e", "input=%s" %vector_name, "format=%s" %format,
-                "output=%s" %file_name]
+        args = ["-e", "input=%s" % vector_name, "format=%s" % format,
+                "output=%s" % file_name]
 
         if additional_options:
             args.extend(additional_options)
@@ -355,10 +355,10 @@ class EphemeralProcessingWithExport(EphemeralProcessing):
         """
 
         module_name = "v.out.postgis"
-        args = ["-l", "input=%s" %vector_name, "output=%s" %dbstring]
+        args = ["-l", "input=%s" % vector_name, "output=%s" % dbstring]
 
         if output_layer:
-            args.append("output_layer=%s" %output_layer)
+            args.append("output_layer=%s" % output_layer)
 
         if additional_options:
             args.extend(additional_options)
@@ -442,7 +442,7 @@ class EphemeralProcessingWithExport(EphemeralProcessing):
                     file_name = resource["value"]
 
                 if output_type == "raster":
-                    message = "Export raster layer <%s> with format %s" %(file_name, resource["export"]["format"])
+                    message = "Export raster layer <%s> with format %s" % (file_name, resource["export"]["format"])
                     self._send_resource_update(message)
                     output_name, output_path = self._export_raster(raster_name=file_name,
                                                                    format=resource["export"]["format"],
@@ -454,12 +454,12 @@ class EphemeralProcessingWithExport(EphemeralProcessing):
                         if "output_layer" in resource["export"]:
                             output_layer = resource["export"]["output_layer"]
 
-                        message = "Export vector layer <%s> to PostgreSQL database" %(file_name)
+                        message = "Export vector layer <%s> to PostgreSQL database" % (file_name)
                         self._send_resource_update(message)
                         self._export_postgis(vector_name=file_name, dbstring=dbstring, output_layer=output_layer)
                         # continue
                     else:
-                        message = "Export vector layer <%s> with format %s" %(file_name, resource["export"]["format"])
+                        message = "Export vector layer <%s> with format %s" % (file_name, resource["export"]["format"])
                         self._send_resource_update(message)
                         output_name, output_path = self._export_vector(vector_name=file_name,
                                                                        format=resource["export"]["format"])
@@ -468,7 +468,7 @@ class EphemeralProcessingWithExport(EphemeralProcessing):
                     tmp_file = resource["tmp_file"]
                     output_name, output_path = self._export_file(tmp_file=tmp_file, file_name=file_name)
                 else:
-                    raise AsyncProcessTermination("Unknown export format %s" %output_type)
+                    raise AsyncProcessTermination("Unknown export format %s" % output_type)
 
                 message = "Moving generated resources to final destination"
                 self._send_resource_update(message)

--- a/src/actinia_core/resources/map_layer_management.py
+++ b/src/actinia_core/resources/map_layer_management.py
@@ -552,9 +552,9 @@ class PersistentRemoveLayers(PersistentProcessing):
         self._execute_process_list(process_list)
 
         if "WARNING: No data base element files found" in "\n".join(self.module_output_log[0]["stderr"]):
-            raise AsyncProcessError("<%s> layer not found" %layer_type)
+            raise AsyncProcessError("<%s> layer not found" % layer_type)
 
-        self.finish_message = "Successfully removed %s layers." %layer_type
+        self.finish_message = "Successfully removed %s layers." % layer_type
 
 def rename_raster_layers(*args):
     processing = PersistentRenameLayers(*args)
@@ -580,7 +580,7 @@ class PersistentRenameLayers(PersistentProcessing):
         # [(a, a_new),(b, b_new),(c, c_new), ...]
         name_list = list()
         for old_name, new_name in  self.request_data:
-            name_list.append("%s,%s" %(old_name, new_name))
+            name_list.append("%s,%s" % (old_name, new_name))
         name_string = ",".join(name_list)
 
         pc = {"1":{"module":"g.rename","inputs":{layer_type:name_string}}}
@@ -599,4 +599,4 @@ class PersistentRenameLayers(PersistentProcessing):
             if "not found" in "\n".join(self.module_output_log[0]["stderr"]):
                 raise AsyncProcessError("Error while renaming map layers")
 
-        self.finish_message = "Successfully renamed %s layers." %layer_type
+        self.finish_message = "Successfully renamed %s layers." % layer_type

--- a/src/actinia_core/resources/persistent_mapset_merger.py
+++ b/src/actinia_core/resources/persistent_mapset_merger.py
@@ -130,16 +130,16 @@ class PersistentMapsetMerger(PersistentProcessing):
         mapset_exists = self._check_mapset(mapset_name)
 
         if mapset_exists is False:
-            raise AsyncProcessError("Mapset <%s> does not exist and can not be locked." %mapset_name)
+            raise AsyncProcessError("Mapset <%s> does not exist and can not be locked." % mapset_name)
 
         # Finally lock the mapset for the time that the user can allocate at maximum
-        lock_id = "%s/%s/%s" %(self.user_group, self.location_name, mapset_name)
+        lock_id = "%s/%s/%s" % (self.user_group, self.location_name, mapset_name)
         ret = self.lock_interface.lock(resource_id=lock_id,
                                        expiration=self.process_time_limit*self.process_num_limit)
 
         if ret == 0:
-            raise AsyncProcessError("Unable to lock mapset <%s>, resource is already locked" %mapset_name)
-        self.message_logger.info("Mapset <%s> locked" %mapset_name)
+            raise AsyncProcessError("Unable to lock mapset <%s>, resource is already locked" % mapset_name)
+        self.message_logger.info("Mapset <%s> locked" % mapset_name)
 
         # if we manage to come here, the lock was correctly set, hence store the lock id for later unlocking
         self.lock_ids[lock_id] = mapset_name
@@ -189,7 +189,7 @@ class PersistentMapsetMerger(PersistentProcessing):
             # Check for termination requests
             if self.resource_logger.get_termination(self.user_id, self.resource_id) is True:
                 raise AsyncProcessTermination("Mapset merging was terminated "
-                                              "by user request at setp %i of %i" %(step, steps))
+                                              "by user request at setp %i of %i" % (step, steps))
 
             mapset_name = self.lock_ids[lock_id]
             mapsets_to_merge.append(mapset_name)
@@ -199,10 +199,10 @@ class PersistentMapsetMerger(PersistentProcessing):
                 ret = self.lock_interface.extend(resource_id=lock_id,
                                                  expiration=self.process_time_limit * 2)
                 if ret == 0:
-                    raise AsyncProcessError("Unable to extend lock for mapset <%s>" %mapset_name)
+                    raise AsyncProcessError("Unable to extend lock for mapset <%s>" % mapset_name)
 
             message = "Step %i of %i: Copy content from source " \
-                      "mapset <%s> into target mapset <%s>" %(step, steps, mapset_name,
+                      "mapset <%s> into target mapset <%s>" % (step, steps, mapset_name,
                                                              self.target_mapset_name)
             self._send_resource_update(message)
             self.message_logger.info(message)

--- a/src/actinia_core/resources/persistent_processing.py
+++ b/src/actinia_core/resources/persistent_processing.py
@@ -47,7 +47,7 @@ __copyright__ = "Copyright 2016-2018, Sören Gebbert and mundialis GmbH & Co. KG
 __maintainer__ = "Sören Gebbert"
 __email__ = "soerengebbert@googlemail.com"
 
-DESCR="""Execute a user defined process chain in an existing mapset
+DESCR = """Execute a user defined process chain in an existing mapset
 of the persistent user database or in a new mapset that will be
 created by this reuqest in the persistent user database.
 
@@ -81,7 +81,7 @@ in an ephemeral database and then merged or copied into the persistent user data
 """
 
 
-SCHEMA_DOC={
+SCHEMA_DOC = {
     'tags': ['Processing'],
     'description': DESCR,
     'consumes':['application/json'],
@@ -275,7 +275,7 @@ class PersistentProcessing(EphemeralProcessing):
             The lock id
 
         """
-        return "%s/%s/%s" %(user_group, location_name, mapset_name)
+        return "%s/%s/%s" % (user_group, location_name, mapset_name)
 
     def _lock_temp_mapset(self):
         """Lock the temporary mapset
@@ -288,8 +288,8 @@ class PersistentProcessing(EphemeralProcessing):
 
         if ret == 0:
             raise AsyncProcessError("Unable to lock temporary mapset <%s>, "
-                                    "resource is already locked" %self.target_mapset_name)
-        self.message_logger.info("Mapset <%s> locked" %self.target_mapset_name)
+                                    "resource is already locked" % self.target_mapset_name)
+        self.message_logger.info("Mapset <%s> locked" % self.target_mapset_name)
 
         # if we manage to come here, the lock was correctly set
         self.temp_mapset_lock_set = True
@@ -324,9 +324,9 @@ class PersistentProcessing(EphemeralProcessing):
                 if os.path.exists(self.orig_mapset_path) is True:
                     if os.access(self.orig_mapset_path, os.R_OK | os.X_OK | os.W_OK) is True:
                         raise AsyncProcessError("Mapset <%s> exists in the global "
-                                                "dataset and can not be modified." %mapset)
+                                                "dataset and can not be modified." % mapset)
             else:
-                raise AsyncProcessError("Unable to access global location <%s>" %self.location_name)
+                raise AsyncProcessError("Unable to access global location <%s>" % self.location_name)
 
         # Always check if the targte mapset already exists and set the flag accordingly
         if os.path.exists(self.user_location_path) and \
@@ -342,12 +342,12 @@ class PersistentProcessing(EphemeralProcessing):
                     self.required_mapsets.append(mapset)
                 else:
                     raise AsyncProcessError("Unable to access mapset <%s> "
-                                            "path %s" %(mapset,
+                                            "path %s" % (mapset,
                                             self.orig_mapset_path))
             else:
                 mapset_exists = False
         else:
-            raise AsyncProcessError("Unable to access user location <%s>" %self.location_name)
+            raise AsyncProcessError("Unable to access user location <%s>" % self.location_name)
 
         return mapset_exists
 
@@ -384,9 +384,9 @@ class PersistentProcessing(EphemeralProcessing):
 
         if ret == 0:
             raise AsyncProcessError("Unable to lock location/mapset <%s/%s>, "
-                                    "resource is already locked" %(self.location_name,
+                                    "resource is already locked" % (self.location_name,
                                                                   self.target_mapset_name))
-        self.message_logger.info("location/mapset <%s/%s> locked" %(self.location_name,
+        self.message_logger.info("location/mapset <%s/%s> locked" % (self.location_name,
                                                                    self.target_mapset_name))
 
         # if we manage to come here, the lock was correctly set
@@ -400,7 +400,7 @@ class PersistentProcessing(EphemeralProcessing):
         Attention: Only raster and vector layers are copied at the moment
         """
         self.message_logger.info("Copy source mapset <%s> content "
-                                 "into the target mapset <%s>" %(source_mapset, target_mapset))
+                                 "into the target mapset <%s>" % (source_mapset, target_mapset))
 
         # Raster adn vector directories
         directories = ["cell", "misc", "fcell",
@@ -422,22 +422,22 @@ class PersistentProcessing(EphemeralProcessing):
                                 print(line.replace(source_mapset, target_mapset), end='')
                         else:
                             raise AsyncProcessError("group %s has no REF file"
-                                                    %(group_dir))
+                                                    % (group_dir))
 
             if os.path.exists(source_path) is True:
                 # Hardlink the sources into the target
-                stdout=subprocess.PIPE
-                stderr=subprocess.PIPE
+                stdout = subprocess.PIPE
+                stderr = subprocess.PIPE
 
                 p = subprocess.Popen(["/bin/cp", "-flr",
-                                      "%s" %source_path,
-                                      "%s/." %target_path],
+                                      "%s" % source_path,
+                                      "%s/." % target_path],
                                      stdout=stdout,
                                      stderr=stderr)
                 (stdout_buff, stderr_buff) = p.communicate()
                 if p.returncode != 0:
                     raise AsyncProcessError("Unable to merge mapsets. Error in linking:"
-                                            " stdout: %s stderr: %s" %(stdout_buff, stderr_buff))
+                                            " stdout: %s stderr: %s" % (stdout_buff, stderr_buff))
 
     def _copy_merge_tmp_mapset_to_target_mapset(self):
         """Copy the temporary mapset into the original location
@@ -453,16 +453,16 @@ class PersistentProcessing(EphemeralProcessing):
                                              expiration=3600)
             if ret == 0:
                 raise AsyncProcessError("Unable to extend lock for mapset "
-                                        "<%s>" %self.target_mapset_name)
+                                        "<%s>" % self.target_mapset_name)
 
         if self.temp_mapset_lock_set is True:
             ret = self.lock_interface.extend(resource_id=self.temp_mapset_lock_id,
                                              expiration=3600)
             if ret == 0:
                 raise AsyncProcessError("Unable to extend lock for "
-                                        "temporary mapset <%s>" %self.temp_mapset_name)
+                                        "temporary mapset <%s>" % self.temp_mapset_name)
 
-        self.message_logger.info("Copy temporary mapset from %s to %s" %(self.temp_mapset_path,
+        self.message_logger.info("Copy temporary mapset from %s to %s" % (self.temp_mapset_path,
                                                                     os.path.join(self.user_location_path,
                                                                                  self.target_mapset_name)))
 
@@ -474,11 +474,11 @@ class PersistentProcessing(EphemeralProcessing):
         if self.target_mapset_exists is True:
             target_path = self.user_location_path + "/."
             message = "Copy temporary mapset <%s> to target location " \
-                      "<%s>" %(self.temp_mapset_name, self.location_name)
+                      "<%s>" % (self.temp_mapset_name, self.location_name)
         else:
             target_path = os.path.join(self.user_location_path, self.target_mapset_name)
             message = "Copy temporary mapset <%s> to target location " \
-                      "<%s>" %(self.target_mapset_name, self.location_name)
+                      "<%s>" % (self.target_mapset_name, self.location_name)
 
         self._send_resource_update(message)
 
@@ -486,20 +486,20 @@ class PersistentProcessing(EphemeralProcessing):
             stdout = subprocess.PIPE
             stderr = subprocess.PIPE
             p = subprocess.Popen(["/bin/cp", "-fr",
-                                  "%s" %source_path,
-                                  "%s" %target_path],
+                                  "%s" % source_path,
+                                  "%s" % target_path],
                                  stdout=stdout,
                                  stderr=stderr)
             (stdout_buff, stderr_buff) = p.communicate()
             if p.returncode != 0:
                 raise AsyncProcessError("Unable to copy temporary mapset to "
                                         "original location. Copy error "
-                                        "stdout: %s stderr: %s returncode: %i" %(stdout_buff,
+                                        "stdout: %s stderr: %s returncode: %i" % (stdout_buff,
                                                                                 stderr_buff,
                                                                                 p.returncode))
         except Exception as e:
             raise AsyncProcessError("Unable to copy temporary mapset to "
-                                    "original location. Exception %s" %str(e))
+                                    "original location. Exception %s" % str(e))
 
         # Merge the temp mapset into the target mapset in case the target already exists
         if self.target_mapset_exists is True:
@@ -521,7 +521,7 @@ class PersistentProcessing(EphemeralProcessing):
                 ret = self.lock_interface.extend(resource_id=self.target_mapset_lock_id,
                                                  expiration=self.process_time_limit * 2)
                 if ret == 0:
-                    raise AsyncProcessError("Unable to extend lock for mapset <%s>" %self.target_mapset_name)
+                    raise AsyncProcessError("Unable to extend lock for mapset <%s>" % self.target_mapset_name)
 
             if self.temp_mapset_lock_set is True:
                 # Extent the lock for each process by max processing time * 2
@@ -529,7 +529,7 @@ class PersistentProcessing(EphemeralProcessing):
                                                  expiration=self.process_time_limit * 2)
                 if ret == 0:
                     raise AsyncProcessError("Unable to extend lock for "
-                                            "temporary mapset <%s>" %self.temp_mapset_name)
+                                            "temporary mapset <%s>" % self.temp_mapset_name)
 
             if process.exec_type == "grass":
                 self._run_module(process)

--- a/src/actinia_core/resources/process_validation.py
+++ b/src/actinia_core/resources/process_validation.py
@@ -44,13 +44,13 @@ __maintainer__ = "Sören Gebbert"
 __email__ = "soerengebbert@googlemail.com"
 
 
-DESCR="""Validate a process chain, check the provided sources (links)
+DESCR = """Validate a process chain, check the provided sources (links)
 and the mapsets. The list of processes that were checked by Actinia are returned in the
 JSON response.
 """
 
 
-SCHEMA_DOC={
+SCHEMA_DOC = {
     'tags': ['Processing'],
     'description': DESCR,
     'consumes':['application/json'],

--- a/src/actinia_core/resources/raster_renderer.py
+++ b/src/actinia_core/resources/raster_renderer.py
@@ -243,9 +243,9 @@ class SyncEphemeralRasterRGBRendererResource(RendererBaseResource):
         if "@" in args["blue"]:
             return self.get_error_response(message="Mapset name is not allowed in layer names")
 
-        options["red"] = "%s@%s" %(args["red"], mapset_name)
-        options["green"] = "%s@%s" %(args["green"], mapset_name)
-        options["blue"] = "%s@%s" %(args["blue"], mapset_name)
+        options["red"] = "%s@%s" % (args["red"], mapset_name)
+        options["green"] = "%s@%s" % (args["green"], mapset_name)
+        options["blue"] = "%s@%s" % (args["blue"], mapset_name)
 
         return options
 
@@ -425,7 +425,7 @@ class EphemeralRasterRGBRenderer(EphemeralRendererBase):
                                                               result_file=result_file)
 
         pc = {}
-        pc["1"] = {"module":"g.region","inputs":{"raster":"%s,%s,%s" %(options["red"],
+        pc["1"] = {"module":"g.region","inputs":{"raster":"%s,%s,%s" % (options["red"],
                                                                       options["green"],
                                                                       options["blue"])}}
         pc["2"] = region_pc
@@ -472,8 +472,8 @@ class SyncEphemeralRasterShapeRendererResource(RendererBaseResource):
         if "@" in args["color"]:
             return self.get_error_response(message="Mapset name is not allowed in layer names")
 
-        options["shade"] = "%s@%s" %(args["shade"], mapset_name)
-        options["color"] = "%s@%s" %(args["color"], mapset_name)
+        options["shade"] = "%s@%s" % (args["shade"], mapset_name)
+        options["color"] = "%s@%s" % (args["color"], mapset_name)
 
         return options
 
@@ -642,7 +642,7 @@ class EphemeralRasterShadeRenderer(EphemeralRendererBase):
                                                               result_file=result_file)
 
         pc = {}
-        pc["1"] = {"module":"g.region","inputs":{"raster":"%s,%s" %(options["shade"],
+        pc["1"] = {"module":"g.region","inputs":{"raster":"%s,%s" % (options["shade"],
                                                                    options["color"])}}
         pc["2"] = region_pc
         pc["3"] = {"module":"d.shade","inputs":{"shade":options["shade"],

--- a/src/actinia_core/resources/renderer_base.py
+++ b/src/actinia_core/resources/renderer_base.py
@@ -37,7 +37,7 @@ __maintainer__ = "Sören Gebbert"
 __email__ = "soerengebbert@googlemail.com"
 
 
-REGION_PARAMETERS={
+REGION_PARAMETERS = {
     'parameters': [
         {
             'name': 'n',

--- a/src/actinia_core/resources/resource_management.py
+++ b/src/actinia_core/resources/resource_management.py
@@ -104,7 +104,7 @@ class ResourceManagerBase(Resource):
         # Check if the user exists
         if new_user.exists() is False:
             return make_response(jsonify(SimpleResponseModel(status="error",
-                                                             message="The user <%s> does not exist" %user_id)), 400)
+                                                             message="The user <%s> does not exist" % user_id)), 400)
 
         # Check admin permissions
         if self.user_role == "admin":
@@ -372,4 +372,4 @@ class ResourcesManager(ResourceManagerBase):
 
         return make_response(jsonify(SimpleResponseModel(status="finished",
                                                          message="Successfully send %i "
-                                                                 "termination requests" %termination_requests)), 200)
+                                                                 "termination requests" % termination_requests)), 200)

--- a/src/actinia_core/resources/resource_storage_management.py
+++ b/src/actinia_core/resources/resource_storage_management.py
@@ -148,7 +148,7 @@ class ResourceStorageSize(EphemeralProcessing):
 
             self.finish_message = "Resource storage size successfully computed"
         else:
-            raise AsyncProcessError("Resource storage directory <%s> does not exist." %self.user_resource_storage_path)
+            raise AsyncProcessError("Resource storage directory <%s> does not exist." % self.user_resource_storage_path)
 
 
 def start_resource_storage_remove(*args):
@@ -179,4 +179,4 @@ class ResourceStorageDelete(PersistentProcessing):
             os.mkdir(self.user_resource_storage_path)
             self.finish_message = "Resource storage successfully removed."
         else:
-            raise AsyncProcessError("Resource storage directory <%s> does not exist." %self.user_resource_storage_path)
+            raise AsyncProcessError("Resource storage directory <%s> does not exist." % self.user_resource_storage_path)

--- a/src/actinia_core/resources/resource_streamer.py
+++ b/src/actinia_core/resources/resource_streamer.py
@@ -83,7 +83,7 @@ class RequestStreamerResource(Resource):
         """
 
         resource_dir = global_config.GRASS_RESOURCE_DIR
-        user_export_path =os.path.join(resource_dir, user_id)
+        user_export_path = os.path.join(resource_dir, user_id)
         resource_export_path = os.path.join(user_export_path, resource_id)
         resource_export_file_path = os.path.join(resource_export_path, file_name)
 

--- a/src/actinia_core/resources/strds_renderer.py
+++ b/src/actinia_core/resources/strds_renderer.py
@@ -215,23 +215,23 @@ class EphemeralSTRDSRenderer(EphemeralRendererBase):
         where_list = []
 
         if "start_time" in options:
-            where_list.append("start_time >= \'%s\'" %options["start_time"])
+            where_list.append("start_time >= \'%s\'" % options["start_time"])
         if "end_time" in options:
-            where_list.append("end_time  <= \'%s\'" %options["end_time"])
+            where_list.append("end_time  <= \'%s\'" % options["end_time"])
         if "n" in options:
-            where_list.append("south <= %f" %options["n"])
+            where_list.append("south <= %f" % options["n"])
         if "s" in options:
-            where_list.append("north >= %f" %options["s"])
+            where_list.append("north >= %f" % options["s"])
         if "e" in options:
-            where_list.append("west <= %f" %options["e"])
+            where_list.append("west <= %f" % options["e"])
         if "w" in options:
-            where_list.append("east >= %f" %options["w"])
+            where_list.append("east >= %f" % options["w"])
 
         where = " AND ".join(where_list)
 
         t_rast_list = {"id": "1",
                        "module": "t.rast.list",
-                       "inputs": [{"param":"input", "value":"%s@%s" %(strds_name, self.mapset_name)},
+                       "inputs": [{"param":"input", "value":"%s@%s" % (strds_name, self.mapset_name)},
                                   {"param":"method", "value":"comma"},
                                   {"param":"where", "value":where}]}
 
@@ -291,8 +291,8 @@ class EphemeralSTRDSRenderer(EphemeralRendererBase):
 
         g_region_adjust = {"id": "4",
                            "module": "g.region",
-                           "inputs": [{"param":"ewres", "value":"%f" %ewres},
-                                      {"param":"nsres", "value":"%f" %nsres}],
+                           "inputs": [{"param":"ewres", "value":"%f" % ewres},
+                                      {"param":"nsres", "value":"%f" % nsres}],
                            "flags":"g"}
 
         d_rast = {"id": "6",

--- a/src/actinia_core/resources/user_api_key.py
+++ b/src/actinia_core/resources/user_api_key.py
@@ -158,8 +158,8 @@ class TokenCreationResource(LoginBase):
             return make_response(jsonify(TokenResponseModel(status="success",
                                          token=g.user.generate_auth_token(expiration=expiration).decode(),
                                          message="Token successfully generated with "
-                                                 "an expiration time of %i seconds" %expiration)))
+                                                 "an expiration time of %i seconds" % expiration)))
         except Exception as e:
             return make_response(jsonify(TokenResponseModel(status="error",
                                          token="",
-                                         message="Error while generating token: %s" %str(e))), 400)
+                                         message="Error while generating token: %s" % str(e))), 400)

--- a/src/actinia_core/resources/user_auth.py
+++ b/src/actinia_core/resources/user_auth.py
@@ -256,7 +256,7 @@ def check_location_mapset_module_access(user_credentials,
 
         if location_name not in accessible_datasets:
             resp = {"Status":"error",
-                    "Messages":"Unauthorized access to location <%s>" %location_name}
+                    "Messages":"Unauthorized access to location <%s>" % location_name}
             return (401, resp)
 
         # Check if the mapset is allowed to be accessed
@@ -265,7 +265,7 @@ def check_location_mapset_module_access(user_credentials,
             if not accessible_datasets[location_name] or \
                             mapset_name not in accessible_datasets[location_name]:
                 resp = {"Status":"error",
-                        "Messages":"Unauthorized access to mapset <%s> in location <%s>" %(mapset_name,
+                        "Messages":"Unauthorized access to mapset <%s> in location <%s>" % (mapset_name,
                                                                                          location_name)}
                 return (401, resp)
 
@@ -274,7 +274,7 @@ def check_location_mapset_module_access(user_credentials,
         accessible_modules = user_credentials["permissions"]["accessible_modules"]
         if module_name not in accessible_modules:
             resp = {"Status":"error",
-                    "Messages":"Module <%s> is not supported" %module_name}
+                    "Messages":"Module <%s> is not supported" % module_name}
             return (401, resp)
 
     return None

--- a/src/actinia_core/resources/user_management.py
+++ b/src/actinia_core/resources/user_management.py
@@ -142,7 +142,7 @@ class UserManagementResource(LoginBase):
         if user.exists() is False:
             return make_response(jsonify(SimpleResponseModel(
                 status="error",
-                message="User <%s> does not exist" %user_id
+                message ="User <%s> does not exist" % user_id
             )), 400)
 
         credentials = user.get_credentials()
@@ -224,12 +224,12 @@ class UserManagementResource(LoginBase):
             if user.exists() is True:
                 return make_response(jsonify(SimpleResponseModel(
                     status="success",
-                    message="User %s created" %user_id
+                    message ="User %s created" % user_id
                 )), 201)
 
         return make_response(jsonify(SimpleResponseModel(
             status="error",
-            message="Unable to create user %s" %user_id
+            message ="Unable to create user %s" % user_id
         )), 400)
 
     @swagger.doc({
@@ -275,16 +275,16 @@ class UserManagementResource(LoginBase):
         if user.exists() is False:
             return make_response(jsonify(SimpleResponseModel(
                 status="error",
-                message="Unable to delete user %s. User does not exist." %user_id
+                message ="Unable to delete user %s. User does not exist." % user_id
             )), 400)
 
         if user.delete() is True:
             return make_response(jsonify(SimpleResponseModel(
                 status="success",
-                message="User %s deleted" %user_id
+                message ="User %s deleted" % user_id
             )), 200)
 
         return make_response(jsonify(SimpleResponseModel(
             status="error",
-            message="Unable to delete user %s" %user_id
+            message ="Unable to delete user %s" % user_id
         )), 400)

--- a/tests/test_api_logging.py
+++ b/tests/test_api_logging.py
@@ -80,7 +80,7 @@ class ApiLoggingTestCase(ActiniaResourceTestCaseBase):
 
         size = self.log.size(self.user_id)
 
-        self.assertEqual(size, 3, "The size method does not work %i" %size)
+        self.assertEqual(size, 3, "The size method does not work %i" % size)
 
         l = self.log.list(self.user_id, start=0, end=-1)
 
@@ -93,7 +93,7 @@ class ApiLoggingTestCase(ActiniaResourceTestCaseBase):
 
         size = self.log.size(self.user_id)
 
-        self.assertEqual(size, 2, "The size method does not work %i" %size)
+        self.assertEqual(size, 2, "The size method does not work %i" % size)
 
         l = self.log.list(self.user_id, start=0, end=-1)
 

--- a/tests/test_async_mapset_merging.py
+++ b/tests/test_async_mapset_merging.py
@@ -117,15 +117,15 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
 
         for mapset in test_mapsets:
                 # Unlock mapset for deletion
-                rv = self.server.delete(URL_PREFIX + '/locations/%s/mapsets/%s/lock' %("nc_spm_08", mapset),
+                rv = self.server.delete(URL_PREFIX + '/locations/%s/mapsets/%s/lock' % ("nc_spm_08", mapset),
                                       headers=self.admin_auth_header)
                 print(rv.data)
 
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         mapsets = json_load(rv.data)["process_results"]
 
@@ -135,8 +135,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
                 rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s' % mapset,
                                         headers=self.admin_auth_header)
                 print(rv.data)
-                self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-                self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+                self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+                self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_1_merge_no_access_to_target_mapset_error(self):
         """No access to target mapset error test"""
@@ -173,8 +173,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/Target',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         ############################################################################
         # Try merge source mapsets into target mapset
@@ -195,8 +195,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/Target',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         ############################################################################
         # Try merge source mapsets into target mapset
@@ -231,8 +231,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/Target',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         ############################################################################
         # Merge source mapsets into target mapset

--- a/tests/test_async_process_postgis_import_export.py
+++ b/tests/test_async_process_postgis_import_export.py
@@ -69,7 +69,7 @@ process_chain_postgis = {
 class AsyncProcessingPostGISTestCase(ActiniaResourceTestCaseBase):
 
     def gen_output_layer_name(self):
-        process_chain_postgis["list"][1]["outputs"][0]["export"]["output_layer"] = "poly_%i" %randint(0, 1000000000)
+        process_chain_postgis["list"][1]["outputs"][0]["export"]["output_layer"] = "poly_%i" % randint(0, 1000000000)
 
     def test_1_async_processing_postgis_validation(self):
         rv = self.server.post(URL_PREFIX + '/locations/latlong_wgs84/process_chain_validation_async',

--- a/tests/test_async_process_validation_errors.py
+++ b/tests/test_async_process_validation_errors.py
@@ -315,8 +315,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_error_webhook_update(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -325,8 +325,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_error_1(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -335,8 +335,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_error_2(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -345,8 +345,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_error_3(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -355,8 +355,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_error_4(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -365,8 +365,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_error_5(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -375,8 +375,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_output_error_1(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -385,8 +385,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_output_error_2(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -395,8 +395,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_landsat_error_1(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -405,8 +405,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_landsat_error_2(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -415,8 +415,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_landsat_error_3(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -425,8 +425,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_sent_error_1(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -435,8 +435,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_sent_error_2(self):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/process_chain_validation_sync',
@@ -445,8 +445,8 @@ class AsyncProcessValidationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 
 if __name__ == '__main__':

--- a/tests/test_async_processing.py
+++ b/tests/test_async_processing.py
@@ -231,8 +231,8 @@ class AsyncProcessTestCase(ActiniaResourceTestCaseBase):
                               data=json_dumps(process_chain),
                               content_type="application/json")
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         resp = json_loads(rv.data)
 
@@ -254,8 +254,8 @@ class AsyncProcessTestCase(ActiniaResourceTestCaseBase):
                                     headers=self.admin_auth_header)
             print("Delete", rv.data.decode())
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         self.assertEqual(resp["status"], "terminated")
 
         time.sleep(1)
@@ -321,8 +321,8 @@ class AsyncProcessTestCase(ActiniaResourceTestCaseBase):
                               headers=self.user_auth_header)
 
         print(rv.data.decode())
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_async_processing_error_6(self):
 

--- a/tests/test_async_processing_export.py
+++ b/tests/test_async_processing_export.py
@@ -380,8 +380,8 @@ class AsyncProcessExportTestCaseUser(ActiniaResourceTestCaseBase):
         for url in urls:
             print(url)
             rv = self.server.get(url, headers=self.user_auth_header)
-            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-            self.assertEqual(rv.mimetype, "image/tiff", "Wrong mimetype %s" %rv.mimetype)
+            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+            self.assertEqual(rv.mimetype, "image/tiff", "Wrong mimetype %s" % rv.mimetype)
 
         time.sleep(1)
 
@@ -511,8 +511,8 @@ class AsyncProcessExportTestCaseAdmin(ActiniaResourceTestCaseBase):
         for url in urls:
             print(url)
             rv = self.server.get(url, headers=self.admin_auth_header)
-            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-            self.assertEqual(rv.mimetype, "image/tiff", "Wrong mimetype %s" %rv.mimetype)
+            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+            self.assertEqual(rv.mimetype, "image/tiff", "Wrong mimetype %s" % rv.mimetype)
 
     def test_termination(self):
 

--- a/tests/test_async_processing_export_file.py
+++ b/tests/test_async_processing_export_file.py
@@ -103,8 +103,8 @@ class AsyncProcessFileExportTestCase(ActiniaResourceTestCaseBase):
         for url in urls:
             print(url)
             rv = self.server.get(url, headers=self.user_auth_header)
-            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-            self.assertEqual(rv.mimetype, "application/zip", "Wrong mimetype %s" %rv.mimetype)
+            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+            self.assertEqual(rv.mimetype, "application/zip", "Wrong mimetype %s" % rv.mimetype)
             print(rv.headers)
             print(rv.iter_encoded())
 
@@ -145,7 +145,7 @@ class AsyncProcessExportTestCaseAdminS3(ActiniaResourceTestCaseBase):
             print(url)
             rv = requests.get(url)
             print(rv)
-            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
+            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
 
     def test_termination(self):
 
@@ -184,7 +184,7 @@ class AsyncProcessExportTestCaseAdminGCS(ActiniaResourceTestCaseBase):
             print(url)
             rv = requests.get(url)
             print(rv)
-            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
+            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
 
     def test_termination(self):
 

--- a/tests/test_async_processing_export_to_storage.py
+++ b/tests/test_async_processing_export_to_storage.py
@@ -110,8 +110,8 @@ class AsyncProcessExport2TestCaseAdmin(ActiniaResourceTestCaseBase):
         for url in urls:
             print(url)
             rv = self.server.get(url, headers=self.user_auth_header)
-            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-            self.assertEqual(rv.mimetype, "image/tiff", "Wrong mimetype %s" %rv.mimetype)
+            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+            self.assertEqual(rv.mimetype, "image/tiff", "Wrong mimetype %s" % rv.mimetype)
             print(rv.headers)
             print(rv.iter_encoded())
 
@@ -137,7 +137,7 @@ class AsyncProcessExportTestCaseAdminS3(ActiniaResourceTestCaseBase):
             print(url)
             rv = requests.get(url)
             print(rv)
-            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
+            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
 
     def test_termination(self):
 
@@ -176,7 +176,7 @@ class AsyncProcessExportTestCaseAdminGCS(ActiniaResourceTestCaseBase):
             print(url)
             rv = requests.get(url)
             print(rv)
-            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
+            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
 
     def test_termination(self):
 

--- a/tests/test_async_processing_mapset.py
+++ b/tests/test_async_processing_mapset.py
@@ -127,8 +127,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         mapsets = json_load(rv.data)["process_results"]
 
@@ -137,8 +137,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
             rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset',
                                     headers=self.admin_auth_header)
             print(rv.data)
-            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-            self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+            self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_1_new_mapset(self):
         """
@@ -156,8 +156,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets',
                              headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         mapsets = json_load(rv.data)["process_results"]
 
@@ -166,8 +166,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset/raster_layers',
                              headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         map_list = json_load(rv.data)["process_results"]
         self.assertTrue("my_accumulation" in map_list)
@@ -178,8 +178,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
         rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_2_existing_mapset(self):
         """
@@ -192,8 +192,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Run the processing using an existing mapset
         # Atemporary mapset will be created and merged in the existing
@@ -206,8 +206,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset/raster_layers',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         map_list = json_load(rv.data)["process_results"]
         self.assertTrue("my_accumulation" in map_list)
@@ -218,8 +218,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
         rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 
     def test_3_existing_mapset_lock(self):
@@ -234,8 +234,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Run the processing inside the new mapset
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset/processing_async',
@@ -244,8 +244,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         resp = json_loads(rv.data)
 
@@ -263,8 +263,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
                                      content_type="application/json")
 
         print(rv_lock_1.data)
-        self.assertEqual(rv_lock_1.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv_lock_1.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv_lock_1.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv_lock_1.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         # Third runner
         rv_lock_2 = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset/processing_async',
                                      headers=self.admin_auth_header,
@@ -272,8 +272,8 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
                                      content_type="application/json")
 
         print(rv_lock_2.data)
-        self.assertEqual(rv_lock_2.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv_lock_2.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv_lock_2.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv_lock_2.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Check the first runner
         while True:
@@ -286,7 +286,7 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
             time.sleep(0.2)
 
         self.assertEquals(resp["status"], "finished")
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
 
         # Check the second runner
         resp = json_loads(rv_lock_1.data)
@@ -302,7 +302,7 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
             time.sleep(0.2)
 
         self.assertEquals(resp["status"], "error")
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
 
         # Check the third runner
         resp = json_loads(rv_lock_2.data)
@@ -319,14 +319,14 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
             time.sleep(0.2)
 
         self.assertEquals(resp["status"], "error")
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
 
         # Remove the mapset
         rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_4_create_global_mapset(self):
 

--- a/tests/test_async_raster_export.py
+++ b/tests/test_async_raster_export.py
@@ -52,8 +52,8 @@ class RasterAsyncExport(ActiniaResourceTestCaseBase):
         for url in urls:
             print(url)
             rv = self.server.get(url, headers=self.user_auth_header)
-            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-            self.assertEqual(rv.mimetype, "image/tiff", "Wrong mimetype %s" %rv.mimetype)
+            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+            self.assertEqual(rv.mimetype, "image/tiff", "Wrong mimetype %s" % rv.mimetype)
             print(rv.headers)
 
         time.sleep(1)
@@ -70,8 +70,8 @@ class RasterAsyncExport(ActiniaResourceTestCaseBase):
         for url in urls:
             print(url)
             rv = self.server.get(url, headers=self.user_auth_header)
-            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-            self.assertEqual(rv.mimetype, "image/tiff", "Wrong mimetype %s" %rv.mimetype)
+            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+            self.assertEqual(rv.mimetype, "image/tiff", "Wrong mimetype %s" % rv.mimetype)
             print(rv.headers)
 
         time.sleep(1)

--- a/tests/test_aws_sentinel_interface.py
+++ b/tests/test_aws_sentinel_interface.py
@@ -164,7 +164,7 @@ class AWSSentinelInterfaceTestCase(unittest.TestCase):
             pprint(result)
             self.assertTrue(False, "The error was not found")
         except Exception as e:
-            self.assertTrue(True, "An exception was raised for the correct reason: %s" %str(e))
+            self.assertTrue(True, "An exception was raised for the correct reason: %s" % str(e))
 
     def otest_query_for_sentinel_scenes_multi_error(self):
         aws = AWSSentinel2AInterface(global_config)
@@ -177,7 +177,7 @@ class AWSSentinelInterfaceTestCase(unittest.TestCase):
             pprint(result)
             self.assertTrue(False, "The error was not found")
         except Exception as e:
-            self.assertTrue(True, "An exception was raised for the correct reason: %s" %str(e))
+            self.assertTrue(True, "An exception was raised for the correct reason: %s" % str(e))
 
     def otest_query_for_sentinel_scenes_band_error(self):
         aws = AWSSentinel2AInterface(global_config)
@@ -188,7 +188,7 @@ class AWSSentinelInterfaceTestCase(unittest.TestCase):
             # pprint(result)
             self.assertTrue(False, "The error was not found")
         except Exception as e:
-            self.assertTrue(True, "An exception was raised for the correct reason: %s" %str(e))
+            self.assertTrue(True, "An exception was raised for the correct reason: %s" % str(e))
 
 
 if __name__ == '__main__':

--- a/tests/test_common_base.py
+++ b/tests/test_common_base.py
@@ -64,8 +64,8 @@ def setup_environment():
     # GRASS
 
     # Setup the test environment
-    global_config.GRASS_GIS_BASE="/usr/local/grass78/"
-    global_config.GRASS_GIS_START_SCRIPT="/usr/local/bin/grass78"
+    global_config.GRASS_GIS_BASE = "/usr/local/grass78/"
+    global_config.GRASS_GIS_START_SCRIPT = "/usr/local/bin/grass78"
     # global_config.GRASS_DATABASE= "/usr/local/grass_test_db"
     # global_config.GRASS_DATABASE = "%s/actinia/grass_test_db" % home
 

--- a/tests/test_download_cache.py
+++ b/tests/test_download_cache.py
@@ -58,8 +58,8 @@ class DownloadCacheTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/download_cache',
                              headers=self.admin_auth_header)
         print(rv.data.decode())
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         self.assertTrue("used" in json_load(rv.data)["process_results"])
         self.assertTrue("quota" in json_load(rv.data)["process_results"])
@@ -69,14 +69,14 @@ class DownloadCacheTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.delete(URL_PREFIX + '/download_cache',
                                 headers=self.admin_auth_header)
         print(rv.data.decode())
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         rv = self.server.get(URL_PREFIX + '/download_cache',
                              headers=self.admin_auth_header)
         print(rv.data.decode())
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         self.assertTrue("used" in json_load(rv.data)["process_results"])
         self.assertTrue("quota" in json_load(rv.data)["process_results"])
@@ -94,8 +94,8 @@ class DownloadCacheTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/download_cache',
                              headers=self.admin_auth_header)
         print(rv.data.decode())
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_download_cache_error_2(self):
 
@@ -108,8 +108,8 @@ class DownloadCacheTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.delete(URL_PREFIX + '/download_cache',
                                 headers=self.admin_auth_header)
         print(rv.data.decode())
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_location_management.py
+++ b/tests/test_location_management.py
@@ -44,8 +44,8 @@ class LocationTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         if "nc_spm_08" in json_loads(rv.data)["locations"]:
             location = "nc_spm_08"
@@ -56,8 +56,8 @@ class LocationTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/info',
                              headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         region_settings = json_loads(rv.data)["process_results"]["region"]
         projection_settings = json_loads(rv.data)["process_results"]["projection"]
@@ -74,8 +74,8 @@ class LocationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json",
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_location_creation_and_deletion(self):
 
@@ -89,8 +89,8 @@ class LocationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json",
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # ERROR: Try to create a location as admin that already exists
         rv = self.server.post(URL_PREFIX + '/locations/test_location',
@@ -98,22 +98,22 @@ class LocationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json",
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Delete location
         rv = self.server.delete(URL_PREFIX + '/locations/test_location',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # ERROR: Delete should fail, since location does not exists
         rv = self.server.delete(URL_PREFIX + '/locations/test_location',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_location_creation_and_deletion_as_user(self):
 
@@ -123,15 +123,15 @@ class LocationTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json",
                               headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # ERROR: Delete should fail since the user is not authorized
         rv = self.server.delete(URL_PREFIX + '/locations/test_location_user',
                                 headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -55,8 +55,8 @@ class ActiniaUserTestCase(ActiniaResourceTestCaseBase):
         """
         rv = self.server.get(URL_PREFIX + '/users', headers=self.admin_auth_header)
         print ("GET /users", rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         users = ""
         if "guest" in json_load(rv.data)["User list"]:
@@ -78,21 +78,21 @@ class ActiniaUserTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.post(URL_PREFIX + '/users/%s?password=%s&group=%s' % (new_user_id, new_password, new_group),
                               headers=self.admin_auth_header)
         print("POST /users/thomas", rv.data)
-        self.assertEqual(rv.status_code, 201, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 201, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Try to create the user again which should fail
         rv = self.server.post(URL_PREFIX + '/users/%s?password=%s&group=%s' % (new_user_id, new_password, new_group),
                               headers=self.admin_auth_header)
         print("POST /users/thomas", rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Get the new user entry
         rv = self.server.get(URL_PREFIX + '/users/thomas', headers=self.admin_auth_header)
         #print("GET /users/thomas", rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         self.assertEquals(json_load(rv.data)["User id"], new_user_id)
         self.assertEquals(json_load(rv.data)["User role"], "user")
@@ -100,8 +100,8 @@ class ActiniaUserTestCase(ActiniaResourceTestCaseBase):
         # Get the admin user entry
         rv = self.server.get(URL_PREFIX + '/users/admin', headers=self.admin_auth_header)
         #print("GET /users/admin", rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         self.assertEquals(json_load(rv.data)["User id"], "admin")
         self.assertEquals(json_load(rv.data)["User role"], "admin")
@@ -109,7 +109,7 @@ class ActiniaUserTestCase(ActiniaResourceTestCaseBase):
         # Delete the user as admin
         rv = self.server.delete(URL_PREFIX + '/users/%s' % new_user_id, headers=self.admin_auth_header)
         print("DELETE /users/thomas", rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
 
     def test_create_get_delete_user_unprivileged(self):
         """
@@ -130,82 +130,82 @@ class ActiniaUserTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.post(URL_PREFIX + '/users/%s?password=%s&group=%s' % (new_user_id, new_password, new_group),
                               headers=new_auth_header)
         print("POST /users/thomas", rv.data)
-        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" % rv.status_code)
 
         # Try to get the user credentials as non-admin which should fail!
         rv = self.server.get(URL_PREFIX + '/users/%s' % new_user_id,
                              headers=new_auth_header)
         print("GET /users/thomas", rv.data)
-        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" % rv.status_code)
 
         # Try to delete the new user as non-admin which should fail!
         rv = self.server.delete(URL_PREFIX + '/users/%s' % new_user_id,
                                 headers=new_auth_header)
         print("DELETE /users/thomas", rv.data)
-        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" % rv.status_code)
 
     def test_token_generation_admin(self):
 
         rv = self.server.get(URL_PREFIX + '/token', headers=self.admin_auth_header)
         print (rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_api_key_generation_admin(self):
 
         rv = self.server.get(URL_PREFIX + '/api_key', headers=self.admin_auth_header)
         print (rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_token_generation_user(self):
 
         rv = self.server.get(URL_PREFIX + '/token', headers=self.user_auth_header)
         print (rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_token_generation_user_expire(self):
 
         rv = self.server.get(URL_PREFIX + '/token?expiration_time=3600', headers=self.user_auth_header)
         print (rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_token_generation_guest(self):
 
         rv = self.server.get(URL_PREFIX + '/token', headers=self.guest_auth_header)
         print (rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_token_generation_wrong_no_auth(self):
 
         rv = self.server.get(URL_PREFIX + '/token')
         print (rv.data)
-        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "text/html", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "text/html", "Wrong mimetype %s" % rv.mimetype)
 
     def test_api_key_generation_wrong_user(self):
 
         rv = self.server.get(URL_PREFIX + '/api_key', headers=self.user_auth_header)
         print (rv.data)
-        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_token_generation_user_expire_error(self):
 
         rv = self.server.get(URL_PREFIX + '/token?expiration_time=1000000000', headers=self.user_auth_header)
         print (rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_token_generation_user_expire_wrong(self):
 
         rv = self.server.get(URL_PREFIX + '/token?expiration_time=blablub', headers=self.user_auth_header)
         print (rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 
 if __name__ == '__main__':

--- a/tests/test_mapset_management.py
+++ b/tests/test_mapset_management.py
@@ -44,8 +44,8 @@ class MapsetTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         mapsets = json_load(rv.data)["process_results"]
 
@@ -56,8 +56,8 @@ class MapsetTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/info',
                              headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         region_settings = json_load(rv.data)["process_results"]["region"]
 
@@ -70,8 +70,8 @@ class MapsetTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/user1/info',
                              headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         region_settings = json_load(rv.data)["process_results"]["region"]
 
@@ -87,49 +87,49 @@ class MapsetTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Delete mapset
         rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Delete should fail, since mapset does not exists
         rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_mapset_creation_and_deletion_unprivileged(self):
         # Create new mapsets as unprivileged user
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset',
                               headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" % rv.status_code)
 
         # Delete mapset as unprivileged user
         rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset',
                                 headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 401, "HTML status code is wrong %i" % rv.status_code)
 
     def test_mapset_deletion_permanent_error(self):
         # Delete PERMANENT
         rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
 
     def test_mapset_deletion_global_db_error(self):
         # Delete PERMANENT
         rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/user1',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
 
     def test_mapset_creation_and_locking(self):
         # Unlock mapset for deletion
@@ -146,22 +146,22 @@ class MapsetTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset_2',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Lock mapset
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset_2/lock',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # get mapset lock(False)
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset_2/lock',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         lock_status = json_load(rv.data)["process_results"]
         self.assertTrue(lock_status)
@@ -170,15 +170,15 @@ class MapsetTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset_2/lock',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # get mapset lock (False)
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset_2/lock',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         lock_status = json_load(rv.data)["process_results"]
         self.assertFalse(lock_status)
@@ -187,15 +187,15 @@ class MapsetTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset_2',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # get mapset lock (False)
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset_2/lock',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         lock_status = json_load(rv.data)["process_results"]
         self.assertFalse(lock_status)
@@ -204,15 +204,15 @@ class MapsetTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset_2/lock',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Unlock mapset
         rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset_2/lock',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_raster_colors.py
+++ b/tests/test_raster_colors.py
@@ -49,8 +49,8 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/colors',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         colors = json_load(rv.data)["process_results"]
         self.assertTrue(len(colors) == 8)
@@ -61,7 +61,7 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         self.create_new_mapset(new_mapset)
 
         # Create
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps({"region":{"n":228500, "s":215000,
                                                          "e":645000,"w":630000,
@@ -69,58 +69,58 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
                                                "expression": "1"}),
                               content_type="application/json")
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         rules = {"rules":["1 0:0:0",]}
 
         # Set the color table
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps(rules),
                               content_type="application/json")
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         rules = {"color":"elevation"}
 
         # Set the color table
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps(rules),
                               content_type="application/json")
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         rules = {"raster":"elevation@PERMANENT"}
 
         # Set the color table
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps(rules),
                               content_type="application/json")
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Delete
-        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                                 headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_1_raster_layer_set_colors_errors(self):
         new_mapset = "raster_test_mapset"
         self.create_new_mapset(new_mapset)
 
         # Create
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps({"region":{"n":228500, "s":215000,
                                                          "e":645000,"w":630000,
@@ -129,20 +129,20 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
                               content_type="application/json")
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         #######################################################################
         rules = {"rules":["wrong format",]}
 
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps(rules),
                               content_type="application/json")
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         log = json_load(rv.data)["message"]
         self.assertTrue("AsyncProcessError:" in log)
@@ -150,66 +150,66 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         #######################################################################
         rules = {"rules":"blub"}
 
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps(rules),
                               content_type="application/json")
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         #######################################################################
         # Two rules
         rules = {"color":"elevation", "raster":"elevation@PERMANENT"}
 
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps(rules),
                               content_type="application/json")
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         #######################################################################
         # Wrong format
         rules = {"nonsense":"bla"}
 
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps(rules),
                               content_type="application/json")
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         #######################################################################
         # Wrong format
         rules = [1,2,3]
 
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps(rules),
                               content_type="application/json")
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         #######################################################################
         # Raster layer not found
         rules = {"raster":"elevation_nope@PERMANENT"}
 
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps(rules),
                               content_type="application/json")
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         log = json_load(rv.data)["message"]
         self.assertTrue("AsyncProcessError:" in log)
@@ -218,30 +218,30 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         # No mapset in name
         rules = {"raster":"elevation"}
 
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer/colors' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps(rules),
                               content_type="application/json")
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         #######################################################################
         # Delete
-        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                                 headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_colors_error_1(self):
         # Raster does not exist
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevat/colors',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         log = json_load(rv.data)["message"]
         self.assertTrue("AsyncProcessError:" in log)

--- a/tests/test_raster_layer.py
+++ b/tests/test_raster_layer.py
@@ -50,7 +50,7 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         self.create_new_mapset(new_mapset)
 
         # Create
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps({"region":{"n":228500, "s":215000,
                                                          "e":645000,"w":630000,
@@ -58,14 +58,14 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
                                                "expression": "1"}),
                               content_type="application/json")
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         # Check
-        rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         minimum = json_load(rv.data)["process_results"]["min"]
         maximum = json_load(rv.data)["process_results"]["max"]
@@ -75,10 +75,10 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         self.assertEqual(maximum, "1")
         self.assertEqual(datatype, "CELL")
         # Delete
-        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                                 headers=self.user_auth_header)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_creation_2(self):
         """Check integer point raster creation"""
@@ -87,7 +87,7 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         self.create_new_mapset(new_mapset)
 
         # Create
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps({"region":{"n":228500, "s":215000,
                                                          "e":645000,"w":630000,
@@ -95,13 +95,13 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
                                                "expression": "1"}),
                               content_type="application/json")
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         # Check
-        rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                              headers=self.user_auth_header)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         minimum = json_load(rv.data)["process_results"]["min"]
         maximum = json_load(rv.data)["process_results"]["max"]
@@ -111,10 +111,10 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         self.assertEqual(maximum, "1")
         self.assertEqual(datatype, "CELL")
         # Delete
-        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                                 headers=self.user_auth_header)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_creation_3(self):
         """Check floating point raster creation"""
@@ -123,7 +123,7 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         self.create_new_mapset(new_mapset)
 
         # Create
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps({"region":{"n":228500, "s":215000,
                                                          "e":645000,"w":630000,
@@ -131,13 +131,13 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
                                                "expression": "1.5"}),
                               content_type="application/json")
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         # Check
-        rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                              headers=self.user_auth_header)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         minimum = json_load(rv.data)["process_results"]["min"]
         maximum = json_load(rv.data)["process_results"]["max"]
@@ -147,10 +147,10 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         self.assertEqual(maximum, "1.5")
         self.assertEqual(datatype, "DCELL")
         # Delete
-        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                                 headers=self.user_auth_header)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_creation_4(self):
         # Remove potentially existing raster layer
@@ -158,7 +158,7 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         self.create_new_mapset(new_mapset)
 
         # Create
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer_1' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer_1' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps({"region":{"n":228500, "s":215000,
                                                          "e":645000,"w":630000,
@@ -166,11 +166,11 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
                                                "expression": "1.0"}),
                               content_type="application/json")
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Create
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer_2' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer_2' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps({"region":{"n":228500, "s":215000,
                                                          "e":645000,"w":630000,
@@ -178,11 +178,11 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
                                                "expression": "2.0"}),
                               content_type="application/json")
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Create
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer_3' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer_3' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps({"region":{"n":228500, "s":215000,
                                                          "e":645000,"w":630000,
@@ -190,22 +190,22 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
                                                "expression": "3.0"}),
                               content_type="application/json")
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Delete
-        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers?pattern=test_layer_*' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers?pattern=test_layer_*' % new_mapset,
                                 headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Delete is empty and fails
-        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers?pattern=test_layer_*' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers?pattern=test_layer_*' % new_mapset,
                                 headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_creation_error_1(self):
         # Remove potentially existing raster layer
@@ -213,7 +213,7 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         self.create_new_mapset(new_mapset)
 
         # Create
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps({"region":{"n":228500, "s":215000,
                                                          "e":645000,"w":630000,
@@ -221,10 +221,10 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
                                                "expression": "1"}),
                               content_type="application/json")
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         # Create fail
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps({"region":{"n":228500, "s":215000,
                                                          "e":645000,"w":630000,
@@ -232,21 +232,21 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
                                                "expression": "1"}),
                               content_type="application/json")
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Delete
-        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                                 headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         # Delete fail
-        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/test_layer' % new_mapset,
                                 headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     #################### INFO #################################################
 
@@ -254,8 +254,8 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         cells = json_load(rv.data)["process_results"]["cells"]
         cols = json_load(rv.data)["process_results"]["cols"]
@@ -270,8 +270,8 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevat',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_raster_layers.py
+++ b/tests/test_raster_layers.py
@@ -44,11 +44,11 @@ class ListRasterLayersTestCase(ActiniaResourceTestCaseBase):
 
     def create_raster_layer(self, mapset_name, raster_name):
         # Remove potentially existing raster layer
-        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/%s' %(mapset_name, raster_name),
+        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/%s' % (mapset_name, raster_name),
                                 headers=self.user_auth_header)
         # print(rv.data)
         # Create
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/%s' %(mapset_name, raster_name),
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/%s' % (mapset_name, raster_name),
                               headers=self.user_auth_header,
                               data=json_dumps({"region":{"n":228500, "s":215000,
                                                          "e":645000,"w":630000,
@@ -56,15 +56,15 @@ class ListRasterLayersTestCase(ActiniaResourceTestCaseBase):
                                                "expression": "1"}),
                               content_type="application/json")
         # print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_list_raster_layers(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers',
                              headers=self.user_auth_header)
         print(rv.data.decode())
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         map_list = json_loads(rv.data)["process_results"]
         self.assertTrue("elevation" in map_list)
@@ -76,8 +76,8 @@ class ListRasterLayersTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers?pattern=lsat*',
                              headers=self.user_auth_header)
         print(rv.data.decode())
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         map_list = json_loads(rv.data)["process_results"]
         self.assertFalse("elevation" in map_list)
@@ -89,8 +89,8 @@ class ListRasterLayersTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers?pattern=NONE',
                              headers=self.user_auth_header)
         print(rv.data.decode())
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         map_list = json_loads(rv.data)["process_results"]
         self.assertTrue(len(map_list) == 0)
@@ -116,11 +116,11 @@ class ListRasterLayersTestCase(ActiniaResourceTestCaseBase):
         #self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s"%rv.mimetype)
 
         # List raster layer
-        rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers?pattern=test_delete_layer_*' %new_mapset,
+        rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers?pattern=test_delete_layer_*' % new_mapset,
                              headers=self.user_auth_header)
         print(rv.data.decode())
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         # Check
         map_list_result = json_loads(rv.data)["process_results"]
         for map_name in map_list_result:
@@ -128,7 +128,7 @@ class ListRasterLayersTestCase(ActiniaResourceTestCaseBase):
 
         # Delete raster layers
         for map_name in map_list:
-            rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/%s' %(new_mapset, map_name),
+            rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/%s' % (new_mapset, map_name),
                                     headers=self.user_auth_header)
             print(rv.data.decode())
 
@@ -147,29 +147,29 @@ class ListRasterLayersTestCase(ActiniaResourceTestCaseBase):
             self.create_raster_layer(new_mapset, map_name)
 
         # Rename raster layer
-        rv = self.server.put(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers' %new_mapset,
+        rv = self.server.put(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers' % new_mapset,
                              headers=self.user_auth_header,
                              data=json_dumps(rename_map_list),
                              content_type="application/json")
         print(rv.data.decode())
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Rename raster layer
-        rv = self.server.put(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers' %new_mapset,
+        rv = self.server.put(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers' % new_mapset,
                              headers=self.user_auth_header,
                              data=json_dumps(rename_map_list),
                              content_type="application/json")
         print(rv.data.decode())
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Delete raster layers
         for map_name in new_map_list:
-            rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/%s' %(new_mapset, map_name),
+            rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/raster_layers/%s' % (new_mapset, map_name),
                                     headers=self.user_auth_header)
             print(rv.data.decode())
-            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
+            self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
 
 
 if __name__ == '__main__':

--- a/tests/test_raster_legend.py
+++ b/tests/test_raster_legend.py
@@ -48,64 +48,64 @@ class RasterLegendTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/legend',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_legend_args_1(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/legend?'
                              'at=0,100,0,20',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_legend_args_2(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/legend?'
                              'range=100,120',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_legend_args_3(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/legend?'
                              '&use=100,110,120',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_legend_args_4(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/legend?'
                              '&fontsize=100',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_legend_args_5(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/legend?'
                              'width=100&heigth=100',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_legend_args_6(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/legend?'
                              'width=100&heigth=100&range=100,120&use=105,110,115&at=0,100,0,30',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_legend_args_7(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/legend?'
                              'labelnum=4',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_legend_args_error_1(self):
         # Wrong "at" parameter
@@ -113,8 +113,8 @@ class RasterLegendTestCase(ActiniaResourceTestCaseBase):
                              'at=-0,-0',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         log = json_load(rv.data)["message"]
         self.assertTrue("AsyncProcessError:" in log)
 
@@ -124,8 +124,8 @@ class RasterLegendTestCase(ActiniaResourceTestCaseBase):
                              'width=-20&at=20,40,20,40',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         log = json_load(rv.data)["message"]
         self.assertFalse("AsyncProcessError:" in log)
 
@@ -135,8 +135,8 @@ class RasterLegendTestCase(ActiniaResourceTestCaseBase):
                              'range=100,120&use=90,130,115',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         log = json_load(rv.data)["message"]
         self.assertTrue("AsyncProcessError:" in log)
 
@@ -146,8 +146,8 @@ class RasterLegendTestCase(ActiniaResourceTestCaseBase):
                              'labelnum=-4',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         log = json_load(rv.data)["message"]
         self.assertTrue("AsyncProcessError:" in log)
 

--- a/tests/test_raster_renderer.py
+++ b/tests/test_raster_renderer.py
@@ -48,32 +48,32 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/render',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_args_1(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/render?'
                              'n=228500&s=215000&w=630000&e=645000',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_args_2(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/render?'
                              'n=228500&s=215000&w=630000&e=645000&width=100&height=100',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_args_3(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevation/render?'
                              'width=100&height=100',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_args_error_1(self):
         # North is smaller then south
@@ -81,8 +81,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              'n=-228500&s=215000',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_args_error_2(self):
         # Negative size
@@ -90,16 +90,16 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              'render?&width=-100&height=-100',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_args_error_3(self):
         # Raster does not exist
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/raster_layers/elevat/render?',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     #################### RGB IMAGE ############################################
 
@@ -108,8 +108,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              'red=lsat5_1987_10&blue=lsat5_1987_20&green=lsat5_1987_30',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_rgb_2(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/landsat/render_rgb?'
@@ -117,8 +117,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                           '&red=lsat5_1987_30&blue=lsat5_1987_20&green=lsat5_1987_10',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_rgb_3(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/landsat/render_rgb?'
@@ -126,8 +126,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                           '&red=lsat5_1987_30&blue=lsat5_1987_20&green=lsat5_1987_10',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_rgb_error_green(self):
         # No green raster layer
@@ -137,8 +137,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              headers=self.user_auth_header)
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_rgb_error_blue(self):
         # No blue raster layer
@@ -148,8 +148,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              headers=self.user_auth_header)
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_rgb_error_red(self):
         # No red raster layer
@@ -159,8 +159,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              headers=self.user_auth_header)
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_rgb_error_wrong_raster(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/landsat/render_rgb?'
@@ -169,8 +169,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              headers=self.user_auth_header)
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_rgb_error_mapset_in_name_1(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/landsat/render_rgb?'
@@ -178,8 +178,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              headers=self.user_auth_header)
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_rgb_error_mapset_in_name_2(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/landsat/render_rgb?'
@@ -187,8 +187,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              headers=self.user_auth_header)
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_rgb_error_mapset_in_name_3(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/landsat/render_rgb?'
@@ -196,8 +196,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              headers=self.user_auth_header)
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     #################### SHADE IMAGE ##########################################
 
@@ -206,8 +206,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              'shade=aspect&color=elevation',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_shade_2(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/render_shade?'
@@ -215,8 +215,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              '&shade=aspect&color=elevation',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_error_mapset_in_name_1(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/render_shade?'
@@ -224,8 +224,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              headers=self.user_auth_header)
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_error_mapset_in_name_2(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/render_shade?'
@@ -233,8 +233,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              headers=self.user_auth_header)
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_raster_layer_image_error_missing_color_1(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/render_shade?'
@@ -242,8 +242,8 @@ class RasterLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              headers=self.user_auth_header)
 
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 
 if __name__ == '__main__':

--- a/tests/test_resource_base.py
+++ b/tests/test_resource_base.py
@@ -66,8 +66,8 @@ def setup_environment():
 
     # GRASS GIS
     # Setup the test environment
-    global_config.GRASS_GIS_BASE="/usr/local/grass78/"
-    global_config.GRASS_GIS_START_SCRIPT="/usr/local/bin/grass78"
+    global_config.GRASS_GIS_BASE = "/usr/local/grass78/"
+    global_config.GRASS_GIS_START_SCRIPT = "/usr/local/bin/grass78"
     # global_config.GRASS_DATABASE= "/usr/local/grass_test_db"
     # global_config.GRASS_DATABASE = "%s/actinia/grass_test_db" % home
     global_config.GRASS_TMP_DATABASE = "/tmp"

--- a/tests/test_resource_storage.py
+++ b/tests/test_resource_storage.py
@@ -58,8 +58,8 @@ class ResourceStorageTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/resource_storage',
                              headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         self.assertTrue("used" in json_load(rv.data)["process_results"])
         self.assertTrue("quota" in json_load(rv.data)["process_results"])
@@ -69,14 +69,14 @@ class ResourceStorageTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.delete(URL_PREFIX + '/resource_storage',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         rv = self.server.get(URL_PREFIX + '/resource_storage',
                              headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         self.assertTrue("used" in json_load(rv.data)["process_results"])
         self.assertTrue("quota" in json_load(rv.data)["process_results"])
@@ -91,8 +91,8 @@ class ResourceStorageTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/resource_storage',
                              headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_resource_storage_error_2(self):
 
@@ -102,8 +102,8 @@ class ResourceStorageTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.delete(URL_PREFIX + '/resource_storage',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_strds_management.py
+++ b/tests/test_strds_management.py
@@ -46,8 +46,8 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/ECAD/mapsets/PERMANENT/strds',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         strds_list = json_loads(rv.data)["process_results"]
         self.assertTrue("precipitation_1950_2013_yearly_mm" in strds_list)
@@ -57,8 +57,8 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + "/locations/ECAD/mapsets/PERMANENT/strds?where=start_time > '1900-01-01'",
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         strds_list = json_loads(rv.data)["process_results"]
         self.assertTrue("precipitation_1950_2013_yearly_mm" in strds_list)
@@ -68,8 +68,8 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + "/locations/ECAD/mapsets/PERMANENT/strds?where=start_time > '2000-01-01'",
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         strds_list = json_loads(rv.data)["process_results"]
 
@@ -81,8 +81,8 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/ECAD/mapsets/PERMANENT/strds/precipitation_1950_2013_yearly_mm',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         start_time = json_loads(rv.data)["process_results"]["start_time"]
 
@@ -96,54 +96,54 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
         self.create_new_mapset(mapset_name=new_mapset, location_name="ECAD")
 
         # Create success
-        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds' % new_mapset,
                               headers=self.admin_auth_header,
                               data=json_dumps({"temporaltype": "absolute",
                                                "title": "A nice title",
                                                "description": "A nice description"}),
                               content_type="application/json")
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Create failure since the strds already exists
-        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds' % new_mapset,
                               headers=self.admin_auth_header,
                               data=json_dumps({"temporaltype": "absolute",
                                                "title": "A nice title",
                                                "description": "A nice description"}),
                               content_type="application/json")
         # print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         # Read/check information of the new strds
-        rv = self.server.get(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds' %new_mapset,
+        rv = self.server.get(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds' % new_mapset,
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         start_time = json_loads(rv.data)["process_results"]["start_time"]
 
         self.assertEquals(start_time, "'None'")
         # Delete the strds
-        rv = self.server.delete(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds' % new_mapset,
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         # Try to delete the strds again to produce an error
-        rv = self.server.delete(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds' % new_mapset,
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
-        rv = self.server.get(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds' %new_mapset,
+        rv = self.server.get(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds' % new_mapset,
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     #################### ERROR ################################################
 
@@ -152,16 +152,16 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/ECAD/mapsets/PERMANENT/strds/precipitation_1950_2013_yearly_mm_nope',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_list_strds_where_error_1(self):
         # Wrong where statement
         rv = self.server.get(URL_PREFIX + "/locations/ECAD/mapsets/PERMANENT/strds?where=start_timing > '2000-01-01'",
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_strds_raster_management.py
+++ b/tests/test_strds_raster_management.py
@@ -53,8 +53,8 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
                                                "description": "A nice description"}),
                               content_type="application/json")
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 
     def test_strds_create_register_unregister_1(self):
@@ -63,28 +63,28 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
         self.create_new_mapset(new_mapset, "ECAD")
 
         # Create success
-        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds_register' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds_register' % new_mapset,
                               headers=self.admin_auth_header,
                               data=json_dumps({"temporaltype": "absolute",
                                                "title": "A nice title",
                                                "description": "A nice description"}),
                               content_type="application/json")
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Create the raster layer
-        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/raster_layers/test_layer_1' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/raster_layers/test_layer_1' % new_mapset,
                               headers=self.admin_auth_header,
                               data=json_dumps({"expression": "1"}),
                               content_type="application/json")
         pprint(json_loads(rv.data))
-        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/raster_layers/test_layer_2' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/raster_layers/test_layer_2' % new_mapset,
                               headers=self.admin_auth_header,
                               data=json_dumps({"expression": "2"}),
                               content_type="application/json")
         pprint(json_loads(rv.data))
-        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/raster_layers/test_layer_3' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/raster_layers/test_layer_3' % new_mapset,
                               headers=self.admin_auth_header,
                               data=json_dumps({"expression": "3"}),
                               content_type="application/json")
@@ -94,20 +94,20 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
                          {"name": "test_layer_2", "start_time": "2000-01-02 00:00:00", "end_time": "2000-01-03 00:00:00"},
                          {"name": "test_layer_3", "start_time": "2000-01-03 00:00:00", "end_time": "2000-01-04 00:00:00"}]
 
-        rv = self.server.put(URL_PREFIX + "/locations/ECAD/mapsets/%s/strds/test_strds_register/raster_layers" %new_mapset,
+        rv = self.server.put(URL_PREFIX + "/locations/ECAD/mapsets/%s/strds/test_strds_register/raster_layers" % new_mapset,
                              data=json_dumps(raster_layers),
                              content_type="application/json",
                              headers=self.admin_auth_header)
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Check strds
-        rv = self.server.get(URL_PREFIX + "/locations/ECAD/mapsets/%s/strds/test_strds_register" %new_mapset,
+        rv = self.server.get(URL_PREFIX + "/locations/ECAD/mapsets/%s/strds/test_strds_register" % new_mapset,
                              headers=self.admin_auth_header)
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         min_min = json_loads(rv.data)["process_results"]["min_min"]
         max_max = json_loads(rv.data)["process_results"]["max_max"]
@@ -119,20 +119,20 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
         # Unregister the raster layers
         raster_layers = ["test_layer_1", "test_layer_2", "test_layer_3"]
 
-        rv = self.server.delete(URL_PREFIX + "/locations/ECAD/mapsets/%s/strds/test_strds_register/raster_layers" %new_mapset,
+        rv = self.server.delete(URL_PREFIX + "/locations/ECAD/mapsets/%s/strds/test_strds_register/raster_layers" % new_mapset,
                                 data=json_dumps(raster_layers),
                                 content_type="application/json",
                                 headers=self.user_auth_header)
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Check strds
-        rv = self.server.get(URL_PREFIX + "/locations/ECAD/mapsets/%s/strds/test_strds_register" %new_mapset,
+        rv = self.server.get(URL_PREFIX + "/locations/ECAD/mapsets/%s/strds/test_strds_register" % new_mapset,
                              headers=self.user_auth_header)
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         min_min = json_loads(rv.data)["process_results"]["min_min"]
         max_max = json_loads(rv.data)["process_results"]["max_max"]
@@ -142,11 +142,11 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
         self.assertEqual(num_maps, "0")
 
         # Delete the strds
-        rv = self.server.delete(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds_register' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds_register' % new_mapset,
                                 headers=self.user_auth_header)
         pprint(json_loads(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     #################### LIST RASTER FROM STRDS ###############################
 
@@ -154,8 +154,8 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/ECAD/mapsets/PERMANENT/strds/precipitation_1950_2013_yearly_mm/raster_layers',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         map_list = json_loads(rv.data)["process_results"]
         self.assertEqual(len(map_list), 63)
@@ -165,8 +165,8 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
                           "where=start_time > '2000-01-01'",
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         map_list = json_loads(rv.data)["process_results"]
         self.assertEqual(len(map_list), 13)
@@ -178,16 +178,16 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/ECAD/mapsets/PERMANENT/strds/precipitation_1950_2013_yearly_mm_nope',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_list_strds_where_error_1(self):
         # Wrong where statement
         rv = self.server.get(URL_PREFIX + "/locations/ECAD/mapsets/PERMANENT/strds?where=start_timing > '2000-01-01'",
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_strds_raster_renderer.py
+++ b/tests/test_strds_raster_renderer.py
@@ -49,28 +49,28 @@ class STRDSRenderTestCase(ActiniaResourceTestCaseBase):
         self.create_new_mapset(new_mapset, "ECAD")
 
         # Create success
-        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds_register' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/strds/test_strds_register' % new_mapset,
                               headers=self.admin_auth_header,
                               data=json_dumps({"temporaltype": "absolute",
                                                "title": "A nice title",
                                                "description": "A nice description"}),
                               content_type="application/json")
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Create the raster layer
-        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/raster_layers/test_layer_1' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/raster_layers/test_layer_1' % new_mapset,
                               headers=self.admin_auth_header,
                               data=json_dumps({"expression": "1"}),
                               content_type="application/json")
         pprint(json_load(rv.data))
-        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/raster_layers/test_layer_2' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/raster_layers/test_layer_2' % new_mapset,
                               headers=self.admin_auth_header,
                               data=json_dumps({"expression": "2"}),
                               content_type="application/json")
         pprint(json_load(rv.data))
-        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/raster_layers/test_layer_3' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/ECAD/mapsets/%s/raster_layers/test_layer_3' % new_mapset,
                               headers=self.admin_auth_header,
                               data=json_dumps({"expression": "3"}),
                               content_type="application/json")
@@ -80,27 +80,27 @@ class STRDSRenderTestCase(ActiniaResourceTestCaseBase):
                          {"name": "test_layer_2", "start_time": "2000-01-02", "end_time": "2000-01-03"},
                          {"name": "test_layer_3", "start_time": "2000-01-03", "end_time": "2000-01-04"}]
 
-        rv = self.server.put(URL_PREFIX + "/locations/ECAD/mapsets/%s/strds/test_strds_register/raster_layers" %new_mapset,
+        rv = self.server.put(URL_PREFIX + "/locations/ECAD/mapsets/%s/strds/test_strds_register/raster_layers" % new_mapset,
                              data=json_dumps(raster_layers),
                              content_type="application/json",
                              headers=self.admin_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Check strds
         rv = self.server.get(URL_PREFIX + "/locations/ECAD/mapsets/%s/strds/test_strds_register/render?"
-                             "width=100&height=100" %new_mapset,
+                             "width=100&height=100" % new_mapset,
                              headers=self.admin_auth_header)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
         # Check strds
         rv = self.server.get(URL_PREFIX + "/locations/ECAD/mapsets/%s/strds/test_strds_register/render?"
-                             "width=100&height=100&start_time=2000-01-01&end_time=2000-01-02" %new_mapset,
+                             "width=100&height=100&start_time=2000-01-01&end_time=2000-01-02" % new_mapset,
                              headers=self.admin_auth_header)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_vector_layer.py
+++ b/tests/test_vector_layer.py
@@ -52,7 +52,7 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         self.create_new_mapset(new_mapset)
 
         # Create
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/vector_layers/test_layer' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/vector_layers/test_layer' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps({"region":{"n":228500, "s":215000,
                                                          "e":645000,"w":630000},
@@ -60,24 +60,24 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
                                                               "zmax":1, "seed":1}}),
                               content_type="application/json")
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Create fail
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/vector_layers/test_layer' %new_mapset,
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/vector_layers/test_layer' % new_mapset,
                               headers=self.user_auth_header,
                               data=json_dumps({"npoints":1, "zmin":1, "zmax":1, "seed":1}),
                               content_type="application/json")
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Check
-        rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/vector_layers/test_layer' %new_mapset,
+        rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/vector_layers/test_layer' % new_mapset,
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         areas = json_load(rv.data)["process_results"]["areas"]
         points = json_load(rv.data)["process_results"]["points"]
@@ -88,25 +88,25 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         self.assertEqual(centroids, "0")
 
         # Delete
-        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/vector_layers/test_layer' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/vector_layers/test_layer' % new_mapset,
                                 headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         # Delete fail
-        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/vector_layers/test_layer' %new_mapset,
+        rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/vector_layers/test_layer' % new_mapset,
                                 headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_layer_info(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/vector_layers/boundary_county',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         areas = json_load(rv.data)["process_results"]["areas"]
         nodes = json_load(rv.data)["process_results"]["nodes"]
@@ -121,8 +121,8 @@ class RasterLayerTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/vector_layers/boundary_county_nope',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_vector_layers.py
+++ b/tests/test_vector_layers.py
@@ -46,8 +46,8 @@ class VectorLayersTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/vector_layers',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         map_list = json_load(rv.data)["process_results"]
         self.assertTrue("boundary_county" in map_list)
@@ -59,8 +59,8 @@ class VectorLayersTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/vector_layers?pattern=elev_*',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         map_list = json_load(rv.data)["process_results"]
         self.assertFalse("boundary_county" in map_list)
@@ -74,8 +74,8 @@ class VectorLayersTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/vector_layers?pattern=NONE',
                              headers=self.user_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         map_list = json_load(rv.data)["process_results"]
         self.assertTrue(len(map_list) == 0)

--- a/tests/test_vector_renderer.py
+++ b/tests/test_vector_renderer.py
@@ -48,32 +48,32 @@ class VectorLayerRendererTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/vector_layers/boundary_county/render',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_vectorlayer_image_args_1(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/vector_layers/boundary_county/render?'
                              'n=228500&s=215000&w=630000&e=645000',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_vectorlayer_image_args_2(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/vector_layers/boundary_county/render?'
                              'n=228500&s=215000&w=630000&e=645000&width=100&height=100',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_vectorlayer_image_args_3(self):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/vector_layers/boundary_county/render?'
                              'width=100&height=100',
                              headers=self.user_auth_header)
 
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "image/png", "Wrong mimetype %s" % rv.mimetype)
 
     def test_vectorlayer_image_args_error_1(self):
         # North is smaller then south
@@ -81,8 +81,8 @@ class VectorLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              'n=-228500&s=215000',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_vectorlayer_image_args_error_2(self):
         # Negative size
@@ -90,16 +90,16 @@ class VectorLayerRendererTestCase(ActiniaResourceTestCaseBase):
                              'render?&width=-100&height=-100',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
     def test_vectorlayer_image_args_error_3(self):
         # Raster does not exist
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/PERMANENT/vector_layers/boundary_county_nomap/render?',
                              headers=self.user_auth_header)
         pprint(json_load(rv.data))
-        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" %rv.status_code)
-        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" %rv.mimetype)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 
 if __name__ == '__main__':

--- a/tests/test_version_health.py
+++ b/tests/test_version_health.py
@@ -43,12 +43,12 @@ class VersionHealthTestCase(ActiniaResourceTestCaseBase):
     def test_version(self):
         rv = self.server.get(URL_PREFIX + '/version')
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
 
     def test_health_check(self):
         rv = self.server.get(URL_PREFIX + '/health_check')
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" %rv.status_code)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
 
 
 if __name__ == '__main__':

--- a/tests_running/test_geodata_import.py
+++ b/tests_running/test_geodata_import.py
@@ -85,14 +85,14 @@ class GeoDataDownloadImportSupportTestCase(unittest.TestCase):
         proc = subprocess.Popen(args=inputlist,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
-        print("Process id: %i" %proc.pid)
+        print("Process id: %i" % proc.pid)
 
         (stdout_buff, stderr_buff) = proc.communicate()
         print(stdout_buff)
         print(stderr_buff)
         proc.wait()
 
-        self.assertEqual(0, proc.returncode, "Error while running %s" %process.executable)
+        self.assertEqual(0, proc.returncode, "Error while running %s" % process.executable)
 
     def test_download_commands_gml(self):
 


### PR DESCRIPTION
```
pycodestyle-3 | grep "missing whitespace" | cut -d' ' -f2- | sort -u
E225 missing whitespace around operator
  ...

ag --python -l | xargs autopep8 --select E225 --in-place
```