### PR TITLE
PEP8: fix various indentation errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -221,14 +221,14 @@ htmlhelp_basename = 'actinia-core-doc'
 # -- Options for LaTeX output --------------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-# 'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    # 'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-# 'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-# 'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/src/actinia_core/resources/common/grass_init.py
+++ b/src/actinia_core/resources/common/grass_init.py
@@ -112,16 +112,16 @@ class GrassEnvironment(ProcessLogging):
         self.env["GRASS_ADDON_PATH"] = grass_addon_path
         self.env["GRASS_ADDON_BASE"] = grass_addon_path
         if os.name != 'posix':
-            self.env["PATH"] = str(os.path.join(self.env["GISBASE"], "bin") + ";"\
-                                   + os.path.join(self.env["GISBASE"], "scripts") + ";"\
-                                   + os.path.join(self.env["GISBASE"], "lib") + ";"\
+            self.env["PATH"] = str(os.path.join(self.env["GISBASE"], "bin") + ";"
+                                   + os.path.join(self.env["GISBASE"], "scripts") + ";"
+                                   + os.path.join(self.env["GISBASE"], "lib") + ";"
                                    + os.path.join(self.env["GISBASE"], "extralib"))
-            self.env["PYTHONPATH"] = str(self.env["PYTHONPATH"] + ";"\
+            self.env["PYTHONPATH"] = str(self.env["PYTHONPATH"] + ";"
                                          + os.path.join(self.env["GISBASE"], "etc", "python"))
         else:
-            self.env["PATH"] = str(os.path.join(self.env["GISBASE"], "bin") + ":"\
+            self.env["PATH"] = str(os.path.join(self.env["GISBASE"], "bin") + ":"
                                    + os.path.join(self.env["GISBASE"], "scripts"))
-            self.env["PYTHONPATH"] = str(self.env["PYTHONPATH"] + ":"\
+            self.env["PYTHONPATH"] = str(self.env["PYTHONPATH"] + ":"
                                          + os.path.join(self.env["GISBASE"], "etc", "python"))
 
         self.set()
@@ -179,8 +179,8 @@ class GrassGisRC(ProcessLogging):
     def write(self, gisrc_path):
         if os.path.isdir(gisrc_path):
             try:
-               self.__gisrc_ile = os.path.join(gisrc_path, "gisrc")
-               self.__write()
+                self.__gisrc_ile = os.path.join(gisrc_path, "gisrc")
+                self.__write()
             except:
                 raise GrassInitError("Error writing the gisrc file")
 

--- a/src/actinia_core/resources/common/landsat_processing_library.py
+++ b/src/actinia_core/resources/common/landsat_processing_library.py
@@ -37,18 +37,18 @@ __email__ = "soerengebbert@googlemail.com"
 SUPPORTED_MIMETYPES = ["application/zip", "application/tiff", "application/gml"]
 
 SCENE_SUFFIXES = {
-"LT04":["_B1.TIF", "_B2.TIF", "_B3.TIF", "_B4.TIF", "_B5.TIF", "_B6.TIF", "_B7.TIF", "_MTL.txt"],
-"LT05":["_B1.TIF", "_B2.TIF", "_B3.TIF", "_B4.TIF", "_B5.TIF", "_B6.TIF", "_B7.TIF", "_MTL.txt"],
-"LE07":["_B1.TIF", "_B2.TIF", "_B3.TIF", "_B4.TIF", "_B5.TIF", "_B6_VCID_2.TIF", "_B6_VCID_1.TIF",
+    "LT04":["_B1.TIF", "_B2.TIF", "_B3.TIF", "_B4.TIF", "_B5.TIF", "_B6.TIF", "_B7.TIF", "_MTL.txt"],
+    "LT05":["_B1.TIF", "_B2.TIF", "_B3.TIF", "_B4.TIF", "_B5.TIF", "_B6.TIF", "_B7.TIF", "_MTL.txt"],
+    "LE07":["_B1.TIF", "_B2.TIF", "_B3.TIF", "_B4.TIF", "_B5.TIF", "_B6_VCID_2.TIF", "_B6_VCID_1.TIF",
         "_B7.TIF", "_B8.TIF","_MTL.txt"],
-"LC08":["_B1.TIF", "_B2.TIF", "_B3.TIF", "_B4.TIF", "_B5.TIF", "_B6.TIF", "_B7.TIF",
+    "LC08":["_B1.TIF", "_B2.TIF", "_B3.TIF", "_B4.TIF", "_B5.TIF", "_B6.TIF", "_B7.TIF",
         "_B8.TIF", "_B9.TIF", "_B10.TIF", "_B11.TIF","_MTL.txt"]}
 
 RASTER_SUFFIXES = {
-"LT04":[".1", ".2", ".3", ".4", ".5", ".6", ".7"],
-"LT05":[".1", ".2", ".3", ".4", ".5", ".6", ".7"],
-"LE07":[".1", ".2", ".3", ".4", ".5", ".61", ".62", ".7", ".8"],
-"LC08":[".1", ".2", ".3", ".4", ".5", ".6", ".7", ".8", ".9", ".10", ".11"]}
+    "LT04":[".1", ".2", ".3", ".4", ".5", ".6", ".7"],
+    "LT05":[".1", ".2", ".3", ".4", ".5", ".6", ".7"],
+    "LE07":[".1", ".2", ".3", ".4", ".5", ".61", ".62", ".7", ".8"],
+    "LC08":[".1", ".2", ".3", ".4", ".5", ".6", ".7", ".8", ".9", ".10", ".11"]}
 
 
 SCENE_BANDS = {"LT04":["B1", "B2", "B3", "B4", "B5", "B6", "B7","MTL"],

--- a/src/actinia_core/resources/common/process_chain.py
+++ b/src/actinia_core/resources/common/process_chain.py
@@ -425,7 +425,7 @@ class ProcessChainModel(Schema):
                             'value': 'LT52170762005240COA00_dos1.1'}],
                 'stdout': {'id': 'stats', 'format': 'kv', 'delimiter': '='},
                 'flags': 'a'
-            },
+        },
             {
                 'module': 'exporter',
                 'id': 'exporter_1',
@@ -433,7 +433,7 @@ class ProcessChainModel(Schema):
                                         'type': 'raster'},
                              'param': 'map',
                              'value': 'LT52170762005240COA00_dos1.1'}]
-            },
+        },
             {
                 "id": "ascii_out",
                 "module": "r.out.ascii",
@@ -442,7 +442,7 @@ class ProcessChainModel(Schema):
                            {"param": "precision", "value": "0"}],
                 "stdout": {"id": "elev_1", "format": "table", "delimiter": " "},
                 "flags": "h"
-            },
+        },
             {
                 "id": "ascii_export",
                 "module": "r.out.ascii",
@@ -453,14 +453,14 @@ class ProcessChainModel(Schema):
                      "param": "output",
                      "value": "$file::out1"}
                 ]
-            },
+        },
             {
                 "id": "raster_list",
                 "module": "g.list",
                 "inputs": [{"param": "type",
                             "value": "raster"}],
                 "stdout": {"id": "raster", "format": "list", "delimiter": "\n"}
-            },
+        },
             {
                 "module": "r.what",
                 "id": "r_what_1",
@@ -485,7 +485,7 @@ class ProcessChainModel(Schema):
                     }
                 ],
                 "stdout": {"id": "sample", "format": "table", "delimiter": "|"}
-            }
+        }
         ],
         'webhooks': {'update': 'http://business-logic.company.com/api/v1/actinia-update-webhook',
                      'finished': 'http://business-logic.company.com/api/v1/actinia-finished-webhook'},

--- a/src/actinia_core/resources/common/process_queue.py
+++ b/src/actinia_core/resources/common/process_queue.py
@@ -203,17 +203,17 @@ class EnqueuedProcess(object):
         """
         if self.process.exitcode is not None and self.process.exitcode != 0:
 
-                # Check if the process noticed the error already
-                response_data = self.resource_logger.get(self.user_id,
-                                                         self.resource_id)
+            # Check if the process noticed the error already
+            response_data = self.resource_logger.get(self.user_id,
+                                                     self.resource_id)
 
-                if response_data is not None:
-                    http_code, response_model = pickle.loads(response_data)
-                    if response_model["status"] != "error" and \
-                            response_model["status"] != "terminated" and \
-                            response_model["status"] != "timeout":
-                        message = "The process unexpectedly terminated with exit code %i" % self.process.exitcode
-                        self._send_resource_update(status="error", message=message, response_data=response_data)
+            if response_data is not None:
+                http_code, response_model = pickle.loads(response_data)
+                if response_model["status"] != "error" and \
+                        response_model["status"] != "terminated" and \
+                        response_model["status"] != "timeout":
+                    message = "The process unexpectedly terminated with exit code %i" % self.process.exitcode
+                    self._send_resource_update(status="error", message=message, response_data=response_data)
 
     def _send_resource_update(self, status, message, response_data=None):
         """Send a response to the resource logger about the current resource state

--- a/src/actinia_core/resources/common/response_models.py
+++ b/src/actinia_core/resources/common/response_models.py
@@ -1247,7 +1247,7 @@ class UserInfoResponseModel(Schema):
             "cell_limit": 100000000000,
             "process_num_limit": 1000,
             "process_time_limit": 31536000
-            },
+        },
         "Status": "success",
         "User group": "superadmin",
         "User id": "actinia-gdi",

--- a/src/actinia_core/resources/ephemeral_processing.py
+++ b/src/actinia_core/resources/ephemeral_processing.py
@@ -514,7 +514,7 @@ class EphemeralProcessing(object):
 
         # Check if the user is allowed to execute this number of processes
         if skip_permission_check == False and len(process_list) > self.process_num_limit:
-            raise AsyncProcessError("Process limit exceeded, a maximum of %i " \
+            raise AsyncProcessError("Process limit exceeded, a maximum of %i "
                                     "processes are allowed in the process chain." % self.process_num_limit)
 
         # Check if the module description was correct and if the
@@ -888,11 +888,11 @@ class EphemeralProcessing(object):
             self.message_logger.info(stdout_buff)
 
             if errorid != 0:
-                raise AsyncProcessError("Unable to adjust the region " \
+                raise AsyncProcessError("Unable to adjust the region "
                                         "settings to nsres: %f ewres: %f error: %s" % (ns_res,
                                                                                        ew_res,
                                                                                        stderr_buff))
-            raise AsyncProcessError("Region to large, set a coarser " \
+            raise AsyncProcessError("Region to large, set a coarser "
                                     "resolution to minimum nsres: %f ewres: %f [num_cells: %d]" % (ns_res,
                                                                                                    ew_res, num_cells))
 

--- a/src/actinia_core/resources/location_management.py
+++ b/src/actinia_core/resources/location_management.py
@@ -249,7 +249,7 @@ class LocationManagementResourceAdmin(ResourceBase):
                     return make_response(jsonify(SimpleResponseModel(status="error",
                                                                      message="Unable to delete "
                                                                              "location %s Exception %s" % (
-                                                                             location_name, str(e)))),
+                                                                                 location_name, str(e)))),
                                          500)
 
         return make_response(jsonify(SimpleResponseModel(status="error",

--- a/src/actinia_core/resources/persistent_processing.py
+++ b/src/actinia_core/resources/persistent_processing.py
@@ -317,7 +317,7 @@ class PersistentProcessing(EphemeralProcessing):
             # Break if the target mapset exists in the global database
             if os.path.exists(self.global_location_path) and \
                     os.path.isdir(self.global_location_path) and \
-                            os.access(self.global_location_path, os.R_OK | os.X_OK | os.W_OK) is True:
+                os.access(self.global_location_path, os.R_OK | os.X_OK | os.W_OK) is True:
 
                 self.orig_mapset_path = os.path.join(self.global_location_path, mapset)
 

--- a/src/actinia_core/resources/user_auth.py
+++ b/src/actinia_core/resources/user_auth.py
@@ -229,9 +229,9 @@ def check_location_mapset_module_access(user_credentials,
 
     # Mapset without location results in error
     if location_name is None and mapset_name is not None:
-            resp = {"Status":"error",
-                    "Messages":"Internal error, mapset definition without location"}
-            return (500, resp)
+        resp = {"Status":"error",
+                "Messages":"Internal error, mapset definition without location"}
+        return (500, resp)
 
     if location_name:
         # Check if the location exists in the global database, if not return
@@ -263,7 +263,7 @@ def check_location_mapset_module_access(user_credentials,
         if mapset_name:
             # Check if the mapset exists in the global database
             if not accessible_datasets[location_name] or \
-                            mapset_name not in accessible_datasets[location_name]:
+                mapset_name not in accessible_datasets[location_name]:
                 resp = {"Status":"error",
                         "Messages":"Unauthorized access to mapset <%s> in location <%s>" % (mapset_name,
                                                                                          location_name)}

--- a/tests/test_async_mapset_merging.py
+++ b/tests/test_async_mapset_merging.py
@@ -43,63 +43,63 @@ __email__ = "soerengebbert@googlemail.com"
 
 process_chain_short_1 = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevation@PERMANENT",
-            "res":"1000"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevation@PERMANENT",
+           "res":"1000"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    },
    2:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect_1"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect_1"
             },
-            "slope":{
-                "name":"my_slope_1"
+           "slope":{
+               "name":"my_slope_1"
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    }
 }
 
 process_chain_short_2 = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevation@PERMANENT",
-            "res":"1000"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevation@PERMANENT",
+           "res":"1000"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    },
    2:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect_2"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect_2"
             },
-            "slope":{
-                "name":"my_slope_2"
+           "slope":{
+               "name":"my_slope_2"
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    }
 }
 
@@ -116,10 +116,10 @@ class AsyncProcessMapsetTestCaseAdmin(ActiniaResourceTestCaseBase):
         """
 
         for mapset in test_mapsets:
-                # Unlock mapset for deletion
-                rv = self.server.delete(URL_PREFIX + '/locations/%s/mapsets/%s/lock' % ("nc_spm_08", mapset),
-                                      headers=self.admin_auth_header)
-                print(rv.data)
+            # Unlock mapset for deletion
+            rv = self.server.delete(URL_PREFIX + '/locations/%s/mapsets/%s/lock' % ("nc_spm_08", mapset),
+                                  headers=self.admin_auth_header)
+            print(rv.data)
 
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets',
                              headers=self.user_auth_header)

--- a/tests/test_async_process_postgis_import_export.py
+++ b/tests/test_async_process_postgis_import_export.py
@@ -58,7 +58,7 @@ process_chain_postgis = {
                                  "output_layer": "poly_2"},
                      "param": "map",
                      "value": "poly"}
-                    ]
+                     ]
          }],
     "webhooks": {"finished": "http://0.0.0.0:5005/webhook/finished",
                  "update": "http://0.0.0.0:5005/webhook/update"},

--- a/tests/test_async_process_validation_errors.py
+++ b/tests/test_async_process_validation_errors.py
@@ -245,7 +245,7 @@ process_chain_sent_1 = {
                                       "type": "sentinel2"},
                      "param": "map",
                      "value": "B04"}]}
-         ],
+    ],
     "version": "1"
 }
 
@@ -258,7 +258,7 @@ process_chain_sent_2 = {
                                       "sentinel_band": "B04"},
                      "param": "map",
                      "value": "B04"}]}
-         ],
+    ],
     "version": "1"
 }
 

--- a/tests/test_async_processing.py
+++ b/tests/test_async_processing.py
@@ -42,58 +42,58 @@ __email__ = "soerengebbert@googlemail.com"
 # Module change example for r.slope.aspect with g.region adjustment
 process_chain = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevation@PERMANENT"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevation@PERMANENT"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    },
    2:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect"
             },
-            "slope":{
-                "name":"my_slope",
-                "export":{
-                    "format":"GTiff",
-                    "type":"raster"
+           "slope":{
+               "name":"my_slope",
+               "export":{
+                   "format":"GTiff",
+                   "type":"raster"
                 }
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    },
    3:{
-        "module":"r.watershed",
-        "inputs":{
-            "elevation":"elevation@PERMANENT"
+       "module":"r.watershed",
+       "inputs":{
+           "elevation":"elevation@PERMANENT"
         },
-        "outputs":{
-            "accumulation":{
-                "name":"my_accumulation",
-                "export":{
-                    "format":"GTiff",
-                    "type":"raster"
+       "outputs":{
+           "accumulation":{
+               "name":"my_accumulation",
+               "export":{
+                   "format":"GTiff",
+                   "type":"raster"
                 }
             }
         }
    },
    4:{
-        "module":"r.info",
-        "inputs":{
-            "map":"my_aspect"
+       "module":"r.info",
+       "inputs":{
+           "map":"my_aspect"
         },
-        "flags":"gr",
-        "verbose":True
+       "flags":"gr",
+       "verbose":True
    },
     5:{
         "executable":"/bin/true",
@@ -111,45 +111,45 @@ process_chain = {
 # Module chains with errors
 process_chain_error_1 = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevation@PERMANENT"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevation@PERMANENT"
         },
-        "flags":"&p",
-        "verbose":True
+       "flags":"&p",
+       "verbose":True
    }
 }
 
 process_chain_error_2 = {
    1:{
-        "module":"g.region_nopo",
-        "inputs":{
-            "raster":"elevation@PERMANENT"
+       "module":"g.region_nopo",
+       "inputs":{
+           "raster":"elevation@PERMANENT"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    }
 }
 
 process_chain_error_3 = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevion@PANENT"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevion@PANENT"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    }
 }
 
 process_chain_error_4 = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "faster":"elevion@PANENT"
+       "module":"g.region",
+       "inputs":{
+           "faster":"elevion@PANENT"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    }
 }
 
@@ -161,54 +161,54 @@ process_chain_error_5 = {
 
 process_chain_error_6 = {
    2:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect"
             },
-            "slope":{
-                "name":"my_slope",
-                "export":{
-                    "fromat":"GTiff",
-                    "type":"raster"
+           "slope":{
+               "name":"my_slope",
+               "export":{
+                   "fromat":"GTiff",
+                   "type":"raster"
                 }
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    },
 }
 
 process_chain_region = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevation@PERMANENT"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevation@PERMANENT"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    },
    2:{
-        "module":"g.region",
-        "inputs":{
-            "res":"0.001"
+       "module":"g.region",
+       "inputs":{
+           "res":"0.001"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    },
    3:{
-        "module":"r.info",
-        "inputs":{
-            "map":"elevation@PERMANENT"
+       "module":"r.info",
+       "inputs":{
+           "map":"elevation@PERMANENT"
         },
-        "flags":"gr",
-        "verbose":True
+       "flags":"gr",
+       "verbose":True
    }
 }
 

--- a/tests/test_async_processing_export.py
+++ b/tests/test_async_processing_export.py
@@ -41,180 +41,180 @@ __email__ = "soerengebbert@googlemail.com"
 # Module change example for r.slope.aspect with g.region adjustment
 process_chain_long = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevation@PERMANENT"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevation@PERMANENT"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    },
    2:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect"
             },
-            "slope":{
-                "name":"my_slope",
-                "export":{
-                    "format":"GTiff",
-                    "type":"raster"
+           "slope":{
+               "name":"my_slope",
+               "export":{
+                   "format":"GTiff",
+                   "type":"raster"
                 }
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    },
    3:{
-        "module":"r.watershed",
-        "inputs":{
-            "elevation":"elevation@PERMANENT"
+       "module":"r.watershed",
+       "inputs":{
+           "elevation":"elevation@PERMANENT"
         },
-        "outputs":{
-            "accumulation":{
-                "name":"my_accumulation",
-                "export":{
-                    "format":"GTiff",
-                    "type":"raster"
+       "outputs":{
+           "accumulation":{
+               "name":"my_accumulation",
+               "export":{
+                   "format":"GTiff",
+                   "type":"raster"
                 }
             }
         }
    },
    4:{
-        "module":"r.info",
-        "inputs":{
-            "map":"my_aspect"
+       "module":"r.info",
+       "inputs":{
+           "map":"my_aspect"
         },
-        "flags":"gr",
-        "verbose":True
+       "flags":"gr",
+       "verbose":True
    },
    5:{
-        "module":"r.info",
-        "inputs":{
-            "map":"my_slope"
+       "module":"r.info",
+       "inputs":{
+           "map":"my_slope"
         },
-        "flags":"gr",
-        "verbose":True
+       "flags":"gr",
+       "verbose":True
    },
    6:{
-        "module":"r.info",
-        "inputs":{
-            "map":"my_accumulation"
+       "module":"r.info",
+       "inputs":{
+           "map":"my_accumulation"
         },
-        "flags":"gr",
-        "verbose":True
+       "flags":"gr",
+       "verbose":True
    },
    7:{
-        "module":"r.info",
-        "inputs":{
-            "map":"my_aspect"
+       "module":"r.info",
+       "inputs":{
+           "map":"my_aspect"
         },
-        "flags":"gr",
-        "verbose":True
+       "flags":"gr",
+       "verbose":True
    },
    8:{
-        "module":"r.info",
-        "inputs":{
-            "map":"my_slope"
+       "module":"r.info",
+       "inputs":{
+           "map":"my_slope"
         },
-        "flags":"gr",
-        "verbose":True
+       "flags":"gr",
+       "verbose":True
    },
    9:{
-        "module":"r.info",
-        "inputs":{
-            "map":"my_accumulation"
+       "module":"r.info",
+       "inputs":{
+           "map":"my_accumulation"
         },
-        "flags":"gr",
-        "verbose":True
+       "flags":"gr",
+       "verbose":True
    },
    10:{
-        "module":"r.info",
-        "inputs":{
-            "map":"my_aspect"
+       "module":"r.info",
+       "inputs":{
+           "map":"my_aspect"
         },
-        "flags":"gr",
-        "verbose":True
+       "flags":"gr",
+       "verbose":True
    },
    11:{
-        "module":"r.info",
-        "inputs":{
-            "map":"my_slope"
+       "module":"r.info",
+       "inputs":{
+           "map":"my_slope"
         },
-        "flags":"gr",
-        "verbose":True
+       "flags":"gr",
+       "verbose":True
    },
    12:{
-        "module":"r.info",
-        "inputs":{
-            "map":"my_accumulation"
+       "module":"r.info",
+       "inputs":{
+           "map":"my_accumulation"
         },
-        "flags":"gr",
-        "verbose":True
+       "flags":"gr",
+       "verbose":True
    }
 }
 
 process_chain_short = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevation@PERMANENT"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevation@PERMANENT"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    },
    2:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect"
             },
-            "slope":{
-                "name":"my_slope",
-                "export":{
-                    "format":"GTiff",
-                    "type":"raster"
+           "slope":{
+               "name":"my_slope",
+               "export":{
+                   "format":"GTiff",
+                   "type":"raster"
                 }
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    }
 }
 
 process_chain_short_long_run = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevation@PERMANENT",
-            "res":"3"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevation@PERMANENT",
+           "res":"3"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    },
    3:{
-        "module":"r.watershed",
-        "inputs":{
-            "elevation":"elevation@PERMANENT"
+       "module":"r.watershed",
+       "inputs":{
+           "elevation":"elevation@PERMANENT"
         },
-        "outputs":{
-            "accumulation":{
-                "name":"my_accumulation",
-                "export":{
-                    "format":"GTiff",
-                    "type":"raster"
+       "outputs":{
+           "accumulation":{
+               "name":"my_accumulation",
+               "export":{
+                   "format":"GTiff",
+                   "type":"raster"
                 }
             }
         }
@@ -223,143 +223,143 @@ process_chain_short_long_run = {
 
 process_chain_short_large_region = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevation@PERMANENT",
-            "res":"0.001"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevation@PERMANENT",
+           "res":"0.001"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    },
    2:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect"
             },
-            "slope":{
-                "name":"my_slope",
-                "export":{
-                    "format":"GTiff",
-                    "type":"raster"
+           "slope":{
+               "name":"my_slope",
+               "export":{
+                   "format":"GTiff",
+                   "type":"raster"
                 }
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    }
 }
 
 # Wrong export "fromat"
 process_chain_error_1 = {
    1:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect"
             },
-            "slope":{
-                "name":"my_slope",
-                "export":{
-                    "fromat":"GTiff",
-                    "type":"raster"
+           "slope":{
+               "name":"my_slope",
+               "export":{
+                   "fromat":"GTiff",
+                   "type":"raster"
                 }
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    },
 }
 
 # Missing export type
 process_chain_error_2 = {
    1:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect"
             },
-            "slope":{
-                "name":"my_slope",
-                "export":{
-                    "format":"GTiff"
+           "slope":{
+               "name":"my_slope",
+               "export":{
+                   "format":"GTiff"
                 }
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    },
 }
 
 # Wrong export type
 process_chain_error_3 = {
    1:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect"
             },
-            "slope":{
-                "name":"my_slope",
-                "export":{
-                    "format":"GTiff",
-                    "type":"raster_blaster"
+           "slope":{
+               "name":"my_slope",
+               "export":{
+                   "format":"GTiff",
+                   "type":"raster_blaster"
                 }
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    },
 }
 
 # Wrong/Unsupported export format
 process_chain_error_4 = {
    1:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect"
             },
-            "slope":{
-                "name":"my_slope",
-                "export":{
-                    "format":"ASCII",
-                    "type":"raster"
+           "slope":{
+               "name":"my_slope",
+               "export":{
+                   "format":"ASCII",
+                   "type":"raster"
                 }
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    },
 }
 

--- a/tests/test_async_processing_export_to_storage.py
+++ b/tests/test_async_processing_export_to_storage.py
@@ -41,52 +41,52 @@ __email__ = "soerengebbert@googlemail.com"
 # Module change example for r.slope.aspect with g.region adjustment
 process_chain_long = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevation@PERMANENT",
-            "res":"1000"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevation@PERMANENT",
+           "res":"1000"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    },
    2:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect",
-                "export":{
-                    "format":"GTiff",
-                    "type":"raster"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect",
+               "export":{
+                   "format":"GTiff",
+                   "type":"raster"
                 }
             },
-            "slope":{
-                "name":"my_slope",
-                "export":{
-                    "format":"GTiff",
-                    "type":"raster"
+           "slope":{
+               "name":"my_slope",
+               "export":{
+                   "format":"GTiff",
+                   "type":"raster"
                 }
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    },
    3:{
-        "module":"r.watershed",
-        "inputs":{
-            "elevation":"elevation@PERMANENT"
+       "module":"r.watershed",
+       "inputs":{
+           "elevation":"elevation@PERMANENT"
         },
-        "outputs":{
-            "accumulation":{
-                "name":"my_accumulation",
-                "export":{
-                    "format":"GTiff",
-                    "type":"raster"
+       "outputs":{
+           "accumulation":{
+               "name":"my_accumulation",
+               "export":{
+                   "format":"GTiff",
+                   "type":"raster"
                 }
             }
         }

--- a/tests/test_async_processing_export_vector.py
+++ b/tests/test_async_processing_export_vector.py
@@ -99,7 +99,7 @@ vector_layer_buffer = {
                 "param": "map",
                 "value": "buf_point"
             }]
-        },
+    },
     ],
     "version": "1"
 }
@@ -148,7 +148,7 @@ vector_layer_clean = {
                 "param": "map",
                 "value": "map_cleaned"
             }]
-        },
+    },
     ],
     "version": "1"
 }

--- a/tests/test_async_processing_mapset.py
+++ b/tests/test_async_processing_mapset.py
@@ -42,80 +42,80 @@ __email__ = "soerengebbert@googlemail.com"
 # Module change example for r.slope.aspect with g.region adjustment
 process_chain_long = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevation@PERMANENT"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevation@PERMANENT"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    },
    2:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect"
             },
-            "slope":{
-                "name":"my_slope"
+           "slope":{
+               "name":"my_slope"
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    },
    3:{
-        "module":"r.watershed",
-        "inputs":{
-            "elevation":"elevation@PERMANENT"
+       "module":"r.watershed",
+       "inputs":{
+           "elevation":"elevation@PERMANENT"
         },
-        "outputs":{
-            "accumulation":{
-                "name":"my_accumulation"
+       "outputs":{
+           "accumulation":{
+               "name":"my_accumulation"
             }
         }
    },
    4:{
-        "module":"r.info",
-        "inputs":{
-            "map":"my_aspect"
+       "module":"r.info",
+       "inputs":{
+           "map":"my_aspect"
         },
-        "flags":"gr",
-        "verbose":True
+       "flags":"gr",
+       "verbose":True
    }
 }
 
 process_chain_short = {
    1:{
-        "module":"g.region",
-        "inputs":{
-            "raster":"elevation@PERMANENT"
+       "module":"g.region",
+       "inputs":{
+           "raster":"elevation@PERMANENT"
         },
-        "flags":"p",
-        "verbose":True
+       "flags":"p",
+       "verbose":True
    },
    2:{
-        "module":"r.slope.aspect",
-        "inputs":{
-            "elevation":"elevation@PERMANENT",
-            "format":"degrees",
-            "min_slope":"0.0"
+       "module":"r.slope.aspect",
+       "inputs":{
+           "elevation":"elevation@PERMANENT",
+           "format":"degrees",
+           "min_slope":"0.0"
         },
-        "outputs":{
-            "aspect":{
-                "name":"my_aspect_2"
+       "outputs":{
+           "aspect":{
+               "name":"my_aspect_2"
             },
-            "slope":{
-                "name":"my_slope_2"
+           "slope":{
+               "name":"my_slope_2"
             }
         },
-        "flags":"a",
-        "overwrite":False,
-        "verbose":True
+       "flags":"a",
+       "overwrite":False,
+       "verbose":True
    }
 }
 


### PR DESCRIPTION
This PR fixes:
- E111  indentation is not a multiple of four
- E115  expected an indented block (comment)
- E117  over-indented
- E122 (^)      continuation line missing indentation or outdented
- E123 (*)      closing bracket does not match indentation of opening bracket’s line
- E124 (^)      closing bracket does not match visual indentation
- E126 (*^)     continuation line over-indented for hanging indent
- E131 (^)      continuation line unaligned for hanging indent
- E502  the backslash is redundant between brackets
- W191  indentation contains tabs
- W291  trailing whitespace
- W292  no newline at end of file

For details, see https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes

```
ag --python -l | xargs autopep8 --select E111,E115,E117,E122,E123,E124,E126,E131,E502,W191,W291,W292 --in-place
```