### PR TITLE
start.sh: silence error when GRASS GIS DB already created

### DIFF
--- a/docker/actinia-core-alpine/start-dev.sh
+++ b/docker/actinia-core-alpine/start-dev.sh
@@ -20,11 +20,11 @@ mkdir -p /tmp/:/root/.grass7
 cp /root/.grass7/dblogin /tmp/:/root/.grass7/
 
 # Create default location in mounted (!) directory
-grass -text -e -c 'EPSG:25832' /actinia_core/grassdb/utm32n
-grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
+[ ! -d "/actinia_core/grassdb/utm32n" ] && grass -text -e -c 'EPSG:25832' /actinia_core/grassdb/utm32n
+[ ! -d "/actinia_core/grassdb/latlong_wgs84" ] && grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
 # TODO: use this location for tests and integrate sample data, see README
 # created here, because set in sample config as default location
-grass -text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
+[ ! -d "/actinia_core/grassdb/nc_spm_08" ] && grass -text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
 
 actinia-user create -u actinia-gdi -w actinia-gdi -r superadmin -g superadmin -c 100000000000 -n 1000 -t 31536000
 actinia-user update -u actinia-gdi -w actinia-gdi

--- a/docker/actinia-core-alpine/start.sh
+++ b/docker/actinia-core-alpine/start.sh
@@ -20,11 +20,11 @@ mkdir -p /tmp/:/root/.grass7
 cp /root/.grass7/dblogin /tmp/:/root/.grass7/
 
 # Create default location in mounted (!) directory
-grass -text -e -c 'EPSG:25832' /actinia_core/grassdb/utm32n
-grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
+[ ! -d "/actinia_core/grassdb/utm32n" ] && grass -text -e -c 'EPSG:25832' /actinia_core/grassdb/utm32n
+[ ! -d "/actinia_core/grassdb/latlong_wgs84" ] && grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
 # TODO: use this location for tests and integrate sample data, see README
 # created here, because set in sample config as default location
-grass -text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
+[ ! -d "/actinia_core/grassdb/nc_spm_08" ] && grass -text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
 
 actinia-user create -u actinia-gdi -w actinia-gdi -r superadmin -g superadmin -c 100000000000 -n 1000 -t 31536000
 actinia-user update -u actinia-gdi -w actinia-gdi

--- a/docker/actinia-core-prod/start.sh
+++ b/docker/actinia-core-prod/start.sh
@@ -8,11 +8,11 @@ mkdir -p /actinia_core/workspace/tmp
 mkdir -p /actinia_core/resources
 
 # Create default location in mounted (!) directory
-grass -text -e -c 'EPSG:25832' /actinia_core/grassdb/utm32n
-grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
+[ ! -d "/actinia_core/grassdb/utm32n" ] && grass -text -e -c 'EPSG:25832' /actinia_core/grassdb/utm32n
+[ ! -d "/actinia_core/grassdb/latlong_wgs84" ] && grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
 # TODO: use this location for tests and integrate sample data, see README
 # created here, because set in sample config as default location
-grass -text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
+[ ! -d "/actinia_core/grassdb/nc_spm_08" ] && grass -text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
 
 # optimized gunicorn settings (http://docs.gunicorn.org/en/stable/design.html) # recommended num of workers is (2 x $num_cores) + 1, here minimum is assumed.
 # If deployed with 8 replicas, each will run with 3 workers.

--- a/docker/actinia-core-ubuntu/start-dev.sh
+++ b/docker/actinia-core-ubuntu/start-dev.sh
@@ -20,11 +20,11 @@ mkdir -p /tmp/:/root/.grass7
 cp /root/.grass7/dblogin /tmp/:/root/.grass7/
 
 # Create default location in mounted (!) directory
-grass -text -e -c 'EPSG:25832' /actinia_core/grassdb/utm32n
-grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
+[ ! -d "/actinia_core/grassdb/utm32n" ] && grass -text -e -c 'EPSG:25832' /actinia_core/grassdb/utm32n
+[ ! -d "/actinia_core/grassdb/latlong_wgs84" ] && grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
 # TODO: use this location for tests and integrate sample data, see README
 # created here, because set in sample config as default location
-grass -text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
+[ ! -d "/actinia_core/grassdb/nc_spm_08" ] && grass -text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
 
 actinia-user create -u actinia-gdi -w actinia-gdi -r superadmin -g superadmin -c 100000000000 -n 1000 -t 31536000
 actinia-user update -u actinia-gdi -w actinia-gdi

--- a/docker/actinia-core-ubuntu/start.sh
+++ b/docker/actinia-core-ubuntu/start.sh
@@ -20,11 +20,11 @@ mkdir -p /tmp/:/root/.grass7
 cp /root/.grass7/dblogin /tmp/:/root/.grass7/
 
 # Create default location in mounted (!) directory
-grass -text -e -c 'EPSG:25832' /actinia_core/grassdb/utm32n
-grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
+[ ! -d "/actinia_core/grassdb/utm32n" ] && grass -text -e -c 'EPSG:25832' /actinia_core/grassdb/utm32n
+[ ! -d "/actinia_core/grassdb/latlong_wgs84" ] && grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
 # TODO: use this location for tests and integrate sample data, see README
 # created here, because set in sample config as default location
-grass -text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
+[ ! -d "/actinia_core/grassdb/nc_spm_08" ] && grass -text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
 
 actinia-user create -u actinia-gdi -w actinia-gdi -r superadmin -g superadmin -c 100000000000 -n 1000 -t 31536000
 actinia-user update -u actinia-gdi -w actinia-gdi


### PR DESCRIPTION
Avoid errors when mounting an existing GRASS GIS DB:

```
sh /src/start.sh
Starting GRASS GIS...
ERROR: Unable to create new location because the location <utm32n> already exists.
Exiting...
Starting GRASS GIS...
ERROR: Unable to create new location because the location <latlong_wgs84> already exists.
Exiting...
Starting GRASS GIS...
ERROR: Unable to create new location because the location <nc_spm_08> already exists.
Exiting...
Created user <actinia-gdi> in group <superadmin>
```

Addresses #119