### PR TITLE
Pin versions for proj-using python libs

### DIFF
--- a/requirements_ubuntu19.txt
+++ b/requirements_ubuntu19.txt
@@ -9,7 +9,7 @@ Flask-RESTful>=0.3.6
 flask-restful-swagger-2
 Flask-Cors>=3.0.3
 fluent-logger>=0.9.4
-geopandas
+geopandas==0.8.1
 google-cloud
 google-cloud-bigquery
 google-cloud-storage
@@ -19,7 +19,7 @@ pandas
 passlib>=1.7.1
 ply>=3.11
 psutil>=5.7.0
-pyproj>=2.2.0
+pyproj==2.6.1
 python-json-logger
 python-magic>=0.4.15
 scikit-learn


### PR DESCRIPTION
for ubuntu based dockerimage to avoid error
` ERROR: Minimum supported proj version is 7.2.0, installed version is 5.2.0. For more information see: https://pyproj4.github.io/pyproj/stable/installation.html`
Versions are taken from latest successfully build ubuntu-based Dockerimage.