### PR TITLE
vector_layers add zone to properties

### DIFF
--- a/src/actinia_core/resources/vector_layer.py
+++ b/src/actinia_core/resources/vector_layer.py
@@ -88,6 +88,7 @@ class VectorInfoModel(Schema):
         'points': {'type': 'string'},
         'primitives': {'type': 'string'},
         'projection': {'type': 'string'},
+        'zone': {'type': 'string'},
         'scale': {'type': 'string'},
         'source_date': {'type': 'string'},
         'south': {'type': 'string'},


### PR DESCRIPTION
`v.info -gte` has a propertie `zone` in locations with UTM zones as projection, which led to an error in actinia:
```
message: "The model "VectorInfoModel" does not have an attribute "zone"",
traceback: [
" File "/usr/lib/python3.8/site-packages/actinia_core/resources/ephemeral_processing.py", line 1356, in run self._execute() ",
" File "/usr/lib/python3.8/site-packages/actinia_core/resources/vector_layer.py", line 631, in _execute self.module_results = VectorInfoModel(**vector_info) ",
" File "/usr/lib/python3.8/site-packages/flask_restful_swagger_2/__init__.py", line 336, in __init__ raise ValueError( "
],
type: "<class 'ValueError'>"
```
This change fixes this bug.