### PR TITLE
docker: update of base image to Ubuntu 20.04

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,17 +1,17 @@
 # actinia version matrix
 
-| docker image  | actinia-core                             | actinia-core-latest                      | actinia-core-dev       | actinia-core-prod           |
-|---------------|------------------------------------------|------------------------------------------|------------------------|-----------------------------|
-| base image    | mundialis/grass-py3-pdal:stable-ubuntu19 | mundialis/grass-py3-pdal:latest-ubuntu19 | mundialis/actinia-core | mundialis/actinia-core:0.99 |
-| [dockerhub tag](https://hub.docker.com/repository/docker/mundialis/actinia-core/tags) | mundialis/actinia:stable | mundialis/actinia:latest |      |       |
-| Linux version | Ubuntu 19.10                             | Ubuntu 19.10                             |                        |                             |
-| GRASS GIS     | 7.8.x                                    | 7.9.x                                    | ?                      | ?                           |
-| GDAL          | 2.4.2                                    | 2.4.2                                    |                        |                             |
-| PROJ          | 5.2.0                                    | 5.2.0                                    |                        |                             |
-| PDAL          | 1.9.1                                    | 1.9.1                                    |                        |                             |
-| Python        | 3.7.5                                    | 3.7.5                                    |                        |                             |
+| docker image  | actinia-core                           | actinia-core-latest                      | actinia-core-dev       | actinia-core-prod           |
+|---------------|----------------------------------------|------------------------------------------|------------------------|-----------------------------|
+| base image    | mundialis/grass-py3-pdal:stable-ubuntu | mundialis/grass-py3-pdal:latest-ubuntu   | mundialis/actinia-core | mundialis/actinia-core:0.99 |
+| [dockerhub tag](https://hub.docker.com/repository/docker/mundialis/actinia-core/tags) | mundialis/actinia:stable | mundialis/actinia:latest |    |       |
+| Linux version | Ubuntu 20.04                           | Ubuntu 20.04                             |                        |                             |
+| GRASS GIS     | 7.8.x                                  | 7.9.x                                    |                        |                             |
+| GDAL          | 3.0.4                                  | 3.0.4                                    |                        |                             |
+| PROJ          | 6.3.1                                  | 6.3.1                                    |                        |                             |
+| PDAL          | 2.2.0                                  | 2.2.0                                    |                        |                             |
+| Python        | 3.8.5                                  | 3.8.5                                    |                        |                             |
 
-Latest update: 7 Jan 2020
+Latest update: 16 Dec 2020
 
 # Requirements
 

--- a/docker/actinia-core-ubuntu/Dockerfile
+++ b/docker/actinia-core-ubuntu/Dockerfile
@@ -1,9 +1,9 @@
-FROM mundialis/grass-py3-pdal:stable-ubuntu19
+FROM mundialis/grass-py3-pdal:stable-ubuntu
 
 # based on GRASS GIS releasebranch_7_8 (grass78)
 
-LABEL authors="Carmen Tawalika,Anika Bettge,Markus Neteler,Sören Gebbert"
-LABEL maintainer="tawalika@mundialis.de,bettge@mundialis.de,neteler@mundialis.de,soerengebbert@gmail.com"
+LABEL authors="Carmen Tawalika,Anika Weinmann,Markus Neteler,Sören Gebbert"
+LABEL maintainer="tawalika@mundialis.de,weinmann@mundialis.de,neteler@mundialis.de,soerengebbert@gmail.com"
 
 ENV GDAL_CACHEMAX=2000
 ENV GRASS_COMPRESSOR=ZSTD
@@ -62,7 +62,7 @@ RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python3 --version
 
-# Install selected GRASS GIS addons. Done with -s, so it can be used globally
+# Install selected GRASS GIS addons. Done with -s, so it can be used by actinia
 # https://grass.osgeo.org/grass79/manuals/g.extension.html
 # -s uses $GISBASE instead of $GRASS_ADDON_BASE
 WORKDIR /src

--- a/docker/actinia-core-ubuntu/README.md
+++ b/docker/actinia-core-ubuntu/README.md
@@ -6,7 +6,7 @@ https://hub.docker.com/r/mundialis/actinia-core
 
 ## Background info
 
-This docker image is based on https://hub.docker.com/r/mundialis/grass-py3-pdal:stable-ubuntu which provides GRASS GIS 7.8 (release branch, grass78) with Python3 and PDAL support.
+This docker image is based on https://hub.docker.com/r/mundialis/grass-py3-pdal (tag: stable-ubuntu) which provides GRASS GIS 7.8 (release branch, grass78) with Python3 and PDAL support.
 
 The Dockerfile contained in this folder is used to build on Dockerhub.
 If you want to build manually...


### PR DESCRIPTION
- switch from `mundialis/grass-py3-pdal:stable-ubuntu19` to `mundialis/grass-py3-pdal:stable-ubuntu`
    - source: https://hub.docker.com/r/mundialis/grass-py3-pdal
- documentation/email updates