### PR TITLE
enhance version output

### DIFF
--- a/src/actinia_core/main.py
+++ b/src/actinia_core/main.py
@@ -29,7 +29,7 @@ Actinia Core
 import os
 from .endpoints import create_endpoints
 from .health_check import health_check
-from .version import version
+from .version import version, init_versions
 from .resources.common.app import flask_app
 from .resources.common.config import global_config, DEFAULT_CONFIG_PATH
 from .resources.common.redis_interface import connect, create_job_queues
@@ -48,6 +48,7 @@ if os.path.exists(DEFAULT_CONFIG_PATH) is True and os.path.isfile(DEFAULT_CONFIG
 
 # Create the endpoints based on the global config
 create_endpoints()
+init_versions()
 
 # TODO: Implement a better error handler
 #@flask_app.errorhandler(InvalidUsage)

--- a/src/actinia_core/version.py
+++ b/src/actinia_core/version.py
@@ -33,9 +33,32 @@ __maintainer__ = "Sören Gebbert"
 __email__ = "soerengebbert@googlemail.com"
 
 from flask import make_response, jsonify
-from .resources.common.app import flask_app, API_VERSION, URL_PREFIX
+import importlib
+import subprocess
+
+from .resources.common.app import flask_app, URL_PREFIX
 from .resources.common.config import global_config
+from .resources.common.logging_interface import log
 from . import __version__
+
+
+G_VERSION = {}
+PLUGIN_VERSIONS = {}
+
+
+def init_versions():
+    g_version = subprocess.run(
+        ['grass', '--tmp-location', 'epsg:4326', '--exec',
+         'g.version', '-rge'], capture_output=True).stdout
+    log.debug('Detecting GRASS GIS version')
+    for i in g_version.decode('utf-8').strip('\n').split('\n'):
+        G_VERSION[i.split('=')[0]] = i.split('=')[1]
+
+    log.debug('Detecting Plugin versions')
+    for i in global_config.PLUGINS:
+        module = importlib.import_module(i)
+        PLUGIN_VERSIONS[i] = module.__version__
+
 
 # Return the version of Actinia Core as REST API call
 @flask_app.route(URL_PREFIX + '/version')
@@ -45,10 +68,10 @@ def version():
     Returns: Response
 
     """
-    info = {"version":__version__, "plugins":",".join(global_config.PLUGINS)}
-
-    if 'actinia_gdi' in global_config.PLUGINS:
-        from actinia_gdi import __version__ as actinia_gdi_version
-        info['plugin_versions'] = {'actinia_gdi': actinia_gdi_version}
+    info = {}
+    info['version'] = __version__
+    info['plugins'] = ",".join(global_config.PLUGINS)
+    info['grass_version'] = G_VERSION
+    info['plugin_versions'] = PLUGIN_VERSIONS
 
     return make_response(jsonify(info), 200)

--- a/src/actinia_core/version.py
+++ b/src/actinia_core/version.py
@@ -35,6 +35,7 @@ __email__ = "soerengebbert@googlemail.com"
 from flask import make_response, jsonify
 import importlib
 import subprocess
+import sys
 
 from .resources.common.app import flask_app, URL_PREFIX
 from .resources.common.config import global_config
@@ -44,9 +45,12 @@ from . import __version__
 
 G_VERSION = {}
 PLUGIN_VERSIONS = {}
+PYTHON_VERSION = ""
 
 
 def init_versions():
+    global PYTHON_VERSION
+
     g_version = subprocess.run(
         ['grass', '--tmp-location', 'epsg:4326', '--exec',
          'g.version', '-rge'], capture_output=True).stdout
@@ -58,6 +62,8 @@ def init_versions():
     for i in global_config.PLUGINS:
         module = importlib.import_module(i)
         PLUGIN_VERSIONS[i] = module.__version__
+
+    PYTHON_VERSION = sys.version.replace('\n', '- ')
 
 
 # Return the version of Actinia Core as REST API call
@@ -73,5 +79,6 @@ def version():
     info['plugins'] = ",".join(global_config.PLUGINS)
     info['grass_version'] = G_VERSION
     info['plugin_versions'] = PLUGIN_VERSIONS
+    info['python_version'] = PYTHON_VERSION
 
     return make_response(jsonify(info), 200)


### PR DESCRIPTION
This PR adds GRASS GIS version and version of all installed actinia plugins to `/version` endpoint. Example:
```
{
  "grass_version": {
    "build_date": "2020-12-16",
    "build_off_t_size": "8",
    "build_platform": "x86_64-pc-linux-musl",
    "date": "2020",
    "gdal": "3.1.4",
    "geos": "3.8.1",
    "libgis_date": "2020-12-16T13:21:23+00:00",
    "libgis_revision": "2020-12-16T13:21:23+00:00",
    "proj": "7.0.1",
    "revision": "exported",
    "sqlite": "3.32.1",
    "version": "7.8.5dev"
  },
  "plugin_versions": {
    "actinia_gdi": "0.1.11",
    "actinia_satellite_plugin": "0.0.2",
    "actinia_statistic_plugin": "0.0.2"
  },
  "plugins": "actinia_statistic_plugin,actinia_satellite_plugin,actinia_gdi",
  "version": "0.99.17.post0.dev1+gd6de7bc.dirty"
}
```