### PR TITLE
fix grass command

### DIFF
--- a/docker/actinia-core-alpine/Dockerfile
+++ b/docker/actinia-core-alpine/Dockerfile
@@ -123,7 +123,7 @@ RUN wget https://grass.osgeo.org/sampledata/north_carolina/nc_spm_08_micro.zip &
   rm -f nc_spm_08_micro.zip && \
   mv nc_spm_08_micro /actinia_core/grassdb/nc_spm_08
 
-RUN grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
+RUN grass -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
 
 RUN wget https://grass.osgeo.org/sampledata/north_carolina/nc_spm_mapset_modis2015_2016_lst_grass79.zip && \
   unzip nc_spm_mapset_modis2015_2016_lst_grass79.zip && \


### PR DESCRIPTION
Due to an update in the GRASS parser (https://github.com/OSGeo/grass/pull/1239), the `-text` parameter leads to an error during the docker build:
```
Step 60/70 : RUN grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84
---> Running in 031c7f746721
[91musage: grass [-h] [-v] [--text] [--gtext] [--gui] [-c [CRS]] [-e]
[--config [CONFIG [CONFIG ...]]] [--tmp-mapset]
[--tmp-location CRS] [-f] [--exec ...]
[PATH]
grass: error: unrecognized arguments: -text
[0m
Removing intermediate container 031c7f746721
The command '/bin/sh -c grass -text -e -c 'EPSG:4326' /actinia_core/grassdb/latlong_wgs84' returned a non-zero code: 2
```
This PR removes the parameter, leading to same result as before.