### PR TITLE
Add stdout as process_result for endpoint locations/{location}}/mapse…

### DIFF
--- a/src/actinia_core/resources/persistent_processing.py
+++ b/src/actinia_core/resources/persistent_processing.py
@@ -591,6 +591,8 @@ class PersistentProcessing(EphemeralProcessing):
         # Copy local mapset to original location, merge mapsets
         # if necessary
         self._copy_merge_tmp_mapset_to_target_mapset()
+        # Parse the module sdtout outputs and create the results
+        self._parse_module_outputs()
 
     def _final_cleanup(self):
         """Final cleanup called in the run function at the very end of processing


### PR DESCRIPTION
In the moment the endpoint `locations/{location}}/processing_async` can put stdout messages in the actinia `process_results`. Eg.:
```
{
  ...
	api_info: {
		endpoint: "asyncephemeralresource",
		method: "POST",
		path: "/api/v1/locations/nc_spm_08/processing_async",
		request_url: "http://localhost:8088/api/v1/locations/nc_spm_08/processing_async"
	},
  ...
	process_chain_list: [{
		list: [{
			flags: "p",
			id: "g.region_stdout_test",
			module: "g.region",
			stdout: {
				delimiter: " ",
				format: "table",
				id: "g_region"
			}
		}],
		version: "1"
	}],
	process_log: [{
		executable: "g.region",
    ...
		stdout: "projection: 99 (Lambert Conformal Conic) zone: 0 datum: nad83 ellipsoid: a=6378137 es=0.006694380022900787 north: 320000 south: 10000 west: 120000 east: 935000 nsres: 500 ewres: 500 rows: 620 cols: 1630 cells: 1010600 "
	}],
	process_results: {
		g_region: [
			[
				"projection: 99 (Lambert Conformal Conic)"
			],
                        ...
			[
				"cells: 1010600"
			]
		]
	},
  ...
}
```

The same PC at the endpoint `locations/{location}}/mapsets/{mapset}/processing_async` does not write it to the `process_results`:
```
{
  ...
	api_info: {
		endpoint: "asyncpersistentresource",
		method: "POST",
		path: "/api/v1/locations/nc_spm_08/mapsets/xx/processing_async",
		request_url: "http://localhost:8088/api/v1/locations/nc_spm_08/mapsets/xx/processing_async"
	},
  ...
	process_chain_list: [{
		list: [{
			flags: "p",
			id: "g.region_stdout_test",
			module: "g.region",
			stdout: {
				delimiter: " ",
				format: "table",
				id: "g_region"
			}
		}],
		version: "1"
	}],
	process_log: [{
		executable: "g.region",
    ...
		stdout: "projection: 99 (Lambert Conformal Conic) zone: 0 datum: nad83 ellipsoid: a=6378137 es=0.006694380022900787 north: 320000 south: 10000 west: 120000 east: 935000 nsres: 500 ewres: 500 rows: 620 cols: 1630 cells: 1010600 "
	}],
	process_results: {},
  ...
}
```
This PR will change this.