### PR TITLE
Monitoring of mapset size of a resource

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ google-cloud-bigquery>=0.28.0
 google-cloud-storage>=1.6.0
 gunicorn>=19.9.0
 joblib==0.15.1
+matplotlib==3.3.4
 passlib>=1.7.1
 ply>=3.11
 psutil>=5.7.0

--- a/requirements_ubuntu19.txt
+++ b/requirements_ubuntu19.txt
@@ -14,6 +14,7 @@ google-cloud
 google-cloud-bigquery
 google-cloud-storage
 gunicorn>=19.9.0
+matplotlib
 numpy>=1.15.4
 pandas
 passlib>=1.7.1

--- a/src/actinia_core/endpoints.py
+++ b/src/actinia_core/endpoints.py
@@ -66,6 +66,7 @@ from .resources.raster_renderer import SyncEphemeralRasterRendererResource
 from .resources.raster_renderer import SyncEphemeralRasterRGBRendererResource
 from .resources.raster_renderer import SyncEphemeralRasterShapeRendererResource
 from .resources.strds_renderer import SyncEphemeralSTRDSRendererResource
+from .resources.process_chain_monitoring import MaxMapsetSizeResource
 
 
 __license__ = "GPLv3"
@@ -161,6 +162,11 @@ def create_core_endpoints():
     # Download and resource management
     flask_api.add_resource(SyncDownloadCacheResource, '/download_cache')
     flask_api.add_resource(SyncResourceStorageResource, '/resource_storage')
+
+    # Endpoints for monitoring a process chain
+    flask_api.add_resource(MaxMapsetSizeResource, '/resources/<string:user_id>/<string:resource_id>/maxmapsetsize')
+    # flask_api.add_resource(MapsetSizeResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsize')
+
 
 
 def check_import_plugins():

--- a/src/actinia_core/endpoints.py
+++ b/src/actinia_core/endpoints.py
@@ -66,7 +66,7 @@ from .resources.raster_renderer import SyncEphemeralRasterRendererResource
 from .resources.raster_renderer import SyncEphemeralRasterRGBRendererResource
 from .resources.raster_renderer import SyncEphemeralRasterShapeRendererResource
 from .resources.strds_renderer import SyncEphemeralSTRDSRendererResource
-from .resources.process_chain_monitoring import MaxMapsetSizeResource
+from .resources.process_chain_monitoring import MaxMapsetSizeResource, MapsetSizeResource, MapsetSizeRenderResource
 
 
 __license__ = "GPLv3"
@@ -164,8 +164,9 @@ def create_core_endpoints():
     flask_api.add_resource(SyncResourceStorageResource, '/resource_storage')
 
     # Endpoints for monitoring a process chain
-    flask_api.add_resource(MaxMapsetSizeResource, '/resources/<string:user_id>/<string:resource_id>/maxmapsetsize')
-    # flask_api.add_resource(MapsetSizeResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsize')
+    flask_api.add_resource(MapsetSizeResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes')
+    flask_api.add_resource(MaxMapsetSizeResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/max')
+    flask_api.add_resource(MapsetSizeRenderResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/render')
 
 
 

--- a/src/actinia_core/endpoints.py
+++ b/src/actinia_core/endpoints.py
@@ -66,7 +66,9 @@ from .resources.raster_renderer import SyncEphemeralRasterRendererResource
 from .resources.raster_renderer import SyncEphemeralRasterRGBRendererResource
 from .resources.raster_renderer import SyncEphemeralRasterShapeRendererResource
 from .resources.strds_renderer import SyncEphemeralSTRDSRendererResource
-from .resources.process_chain_monitoring import MaxMapsetSizeResource, MapsetSizeResource, MapsetSizeRenderResource, MapsetSizeDiffResource, MapsetSizeDiffRenderResource
+from .resources.process_chain_monitoring import \
+    MaxMapsetSizeResource, MapsetSizeResource, MapsetSizeRenderResource, \
+    MapsetSizeDiffResource, MapsetSizeDiffRenderResource
 
 
 __license__ = "GPLv3"
@@ -164,11 +166,21 @@ def create_core_endpoints():
     flask_api.add_resource(SyncResourceStorageResource, '/resource_storage')
 
     # Endpoints for monitoring a process chain
-    flask_api.add_resource(MapsetSizeResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes')
-    flask_api.add_resource(MaxMapsetSizeResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/max')
-    flask_api.add_resource(MapsetSizeRenderResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/render')
-    flask_api.add_resource(MapsetSizeDiffResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/diffs')
-    flask_api.add_resource(MapsetSizeDiffRenderResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/diffs/render')
+    flask_api.add_resource(
+        MapsetSizeResource,
+        '/resources/<string:user_id>/<string:resource_id>/mapsetsizes')
+    flask_api.add_resource(
+        MaxMapsetSizeResource,
+        '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/max')
+    flask_api.add_resource(
+        MapsetSizeRenderResource,
+        '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/render')
+    flask_api.add_resource(
+        MapsetSizeDiffResource,
+        '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/diffs')
+    flask_api.add_resource(
+        MapsetSizeDiffRenderResource,
+        '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/diffs/render')
 
 
 

--- a/src/actinia_core/endpoints.py
+++ b/src/actinia_core/endpoints.py
@@ -183,7 +183,6 @@ def create_core_endpoints():
         '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/diffs/render')
 
 
-
 def check_import_plugins():
     import_str = """from {}.endpoints import create_endpoints as create_plugin_endpoints
 create_plugin_endpoints(flask_api=flask_api)

--- a/src/actinia_core/endpoints.py
+++ b/src/actinia_core/endpoints.py
@@ -66,7 +66,7 @@ from .resources.raster_renderer import SyncEphemeralRasterRendererResource
 from .resources.raster_renderer import SyncEphemeralRasterRGBRendererResource
 from .resources.raster_renderer import SyncEphemeralRasterShapeRendererResource
 from .resources.strds_renderer import SyncEphemeralSTRDSRendererResource
-from .resources.process_chain_monitoring import MaxMapsetSizeResource, MapsetSizeResource, MapsetSizeRenderResource
+from .resources.process_chain_monitoring import MaxMapsetSizeResource, MapsetSizeResource, MapsetSizeRenderResource, MapsetSizeDiffResource, MapsetSizeDiffRenderResource
 
 
 __license__ = "GPLv3"
@@ -167,6 +167,8 @@ def create_core_endpoints():
     flask_api.add_resource(MapsetSizeResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes')
     flask_api.add_resource(MaxMapsetSizeResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/max')
     flask_api.add_resource(MapsetSizeRenderResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/render')
+    flask_api.add_resource(MapsetSizeDiffResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/diffs')
+    flask_api.add_resource(MapsetSizeDiffRenderResource, '/resources/<string:user_id>/<string:resource_id>/mapsetsizes/diffs/render')
 
 
 

--- a/src/actinia_core/resources/common/response_models.py
+++ b/src/actinia_core/resources/common/response_models.py
@@ -115,6 +115,11 @@ class ProcessLogModel(Schema):
             'type': 'number',
             'format': 'float',
             'description': 'The runtime of the executable in seconds'
+        },
+        'mapset_size': {
+            'type': 'number',
+            'format': 'float',
+            'description': 'The size of the mapset in bytes'
         }
     }
     required = ['executable', 'parameter', 'stdout', 'stderr', 'return_code']

--- a/src/actinia_core/resources/ephemeral_processing.py
+++ b/src/actinia_core/resources/ephemeral_processing.py
@@ -1261,12 +1261,17 @@ class EphemeralProcessing(object):
 
         process.set_stdouts(stdout=stdout_string, stderr=stderr_string)
 
-        plm = ProcessLogModel(executable=process.executable,
-                              parameter=process.executable_params,
-                              return_code=proc.returncode,
-                              stdout=stdout_string,
-                              stderr=stderr_string.split("\n"),
-                              run_time=run_time)
+        kwargs = {
+            'executable': process.executable,
+            'parameter': process.executable_params,
+            'return_code': proc.returncode,
+            'stdout': stdout_string,
+            'stderr': stderr_string.split("\n"),
+            'run_time': run_time}
+        if self.temp_mapset_path:
+            kwargs['mapset_size'] = self._get_directory_size(self.temp_mapset_path)
+
+        plm = ProcessLogModel(**kwargs)
 
         self.module_output_log.append(plm)
         # Store the log in an additional dictionary for automated output generation

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+#######
+# actinia-core - an open source REST API for scalable, distributed, high
+# performance processing of geographical data that uses GRASS GIS for
+# computational tasks. For details, see https://actinia.mundialis.de/
+#
+# Copyright (c) 2016-2018 Sören Gebbert and mundialis GmbH & Co. KG
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#######
+
+"""
+Process Chain Monitoring
+"""
+
+import pickle
+from flask import jsonify, make_response
+from flask_restful_swagger_2 import swagger, Schema
+
+from .resource_management import ResourceManager
+from .common.response_models import ProcessingResponseModel, SimpleResponseModel
+
+__license__ = "GPLv3"
+__author__ = "Anika Weinmann"
+__copyright__ = "Copyright 2021, mundialis GmbH & Co. KG"
+__maintainer__ = "mudnialis"
+__email__ = "info@mudnialis.de"
+
+
+class MaxMapsetSizeResponseModel(Schema):
+    """Response schema for maximum mapset size of a resouce
+    """
+    type = 'object'
+    properties = {
+        'status': {
+            'type': 'string',
+            'description': 'The status of the resource, values: success, error'
+        },
+        'max_mapset_size': {
+            'type': 'integer',
+            'description': 'The maximum mapset size of a resource in bytes'
+        }
+    }
+    example = {"max_mapset_size": 29949, "status": "success"}
+    required = ["status", "max_mapset_size"]
+
+
+class MaxMapsetSizeResource(ResourceManager):
+    """
+    This class return the maximum mapset size of a resource
+    """
+    def __init__(self):
+
+        # Configuration
+        ResourceManager.__init__(self)
+
+    @swagger.doc({
+        'tags': ['Process Chain Monitoring'],
+        'description': 'Get the maximum mapset size of a resource. Minimum required user role: user.',
+        'parameters': [
+            {
+                'name': 'user_id',
+                'description': 'The unique user name/id',
+                'required': True,
+                'in': 'path',
+                'type': 'string'
+            },
+            {
+                'name': 'resource_id',
+                'description': 'The id of the resource',
+                'required': True,
+                'in': 'path',
+                'type': 'string'
+            }
+        ],
+        'responses': {
+            '200': {
+                'description': 'The current state of the resource',
+                'schema':MaxMapsetSizeResponseModel
+            },
+            '400': {
+                'description': 'The error message if the resource does not exists',
+                'schema':SimpleResponseModel
+            }
+        }
+    })
+    def get(self, user_id, resource_id):
+        """Get the maximum size of mapset of a resource."""
+
+        ret = self.check_permissions(user_id=user_id)
+        if ret:
+            return ret
+
+        response_data = self.resource_logger.get(user_id, resource_id)
+
+        if response_data is not None:
+            http_code, pc_response_model = pickle.loads(response_data)
+
+            pc_status = pc_response_model['status']
+            if pc_status in ['accepted', 'running']:
+                return make_response(jsonify(SimpleResponseModel(
+                    status="error",
+                    message="Resource is not ready it is %s" % pc_status)),
+                    400)
+
+            mapset_sizes = [proc['mapset_size']
+                for proc in pc_response_model['process_log']]
+            max_mapset_size = max(mapset_sizes)
+
+            return make_response(
+                jsonify(MaxMapsetSizeResponseModel(
+                status="success", max_mapset_size=max_mapset_size)), http_code)
+        else:
+            return make_response(jsonify(SimpleResponseModel(
+                status="error",
+                message="Resource does not exist")), 400)

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -121,7 +121,7 @@ class MapsetSizeResource(ResourceManager):
                 'schema': MapsetSizeResponseModel
             },
             '400': {
-                'description': 'The error message if the resource does not exists',
+                'description': 'The error message if the resource does not exist',
                 'schema': SimpleResponseModel
             }
         }

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -87,7 +87,7 @@ class MapsetSizeResponseModel(Schema):
 
 class MapsetSizeResource(ResourceManager):
     """
-    This class return the mapset sizes of a resource
+    This class returns the mapset sizes of a resource
     """
     def __init__(self):
 
@@ -157,7 +157,7 @@ class MapsetSizeResource(ResourceManager):
 
 class MapsetSizeDiffResource(ResourceManager):
     """
-    This class return the mapset size differences of a resource
+    This class returns the mapset size differences of a resource
     """
     def __init__(self):
 
@@ -246,7 +246,7 @@ class MaxMapsetSizeResponseModel(Schema):
 
 class MaxMapsetSizeResource(ResourceManager):
     """
-    This class return the maximum mapset size of a resource
+    This class returns the maximum mapset size of a resource
     """
     def __init__(self):
 

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -440,7 +440,7 @@ class MapsetSizeDiffRenderResource(ResourceManager):
                 'description': 'The PNG image'},
             '400': {
                 'description': 'The error message and a detailed log why '
-                               'rendering did not succeeded',
+                               'rendering did not succeed',
                 'schema': SimpleResponseModel
             }
         }

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -33,7 +33,7 @@ from flask import jsonify, make_response, Response
 from flask_restful_swagger_2 import swagger, Schema
 
 from .resource_management import ResourceManager
-from .common.response_models import ProcessingResponseModel, SimpleResponseModel
+from .common.response_models import SimpleResponseModel
 
 __license__ = "GPLv3"
 __author__ = "Anika Weinmann"
@@ -45,15 +45,14 @@ __email__ = "info@mundialis.de"
 def create_scatter_plot(x, y, xlabel, ylabel, title):
 
     plt.clf()
-    plt.scatter(x, y, s=np.pi*5, c=(1,0,0))
+    plt.scatter(x, y, s=(np.pi * 5), c=(1, 0, 0))
     plt.title(title, fontsize=14)
     plt.xlabel(xlabel, fontsize=12)
     plt.ylabel(ylabel, fontsize=12)
     y_up = (max(y) + 9) // 10 * 10
     plt.ylim(0, y_up)
-    y_len = len(y)
     step = y_up / 10
-    plt.xticks(np.arange(1, len(y) + 1, step=1))
+    plt.xticks(np.arange(1, len(y) + 1, step=step))
     with NamedTemporaryFile(suffix='.png', mode="wb", delete=False) as f:
         plt.savefig(f)
     return f.name
@@ -61,9 +60,10 @@ def create_scatter_plot(x, y, xlabel, ylabel, title):
 
 def compute_mapset_size_diffs(mapset_sizes):
     diffs = [None] * len(mapset_sizes)
-    diffs[0] = mapset_sizes[0] # TODO not correct cause an empty mapset has also a size!
+    # TODO not correct cause an empty mapset has also a size!
+    diffs[0] = mapset_sizes[0]
     for i in range(1, len(mapset_sizes)):
-        diffs[i] = mapset_sizes[i] - mapset_sizes[i-1]
+        diffs[i] = mapset_sizes[i] - mapset_sizes[i - 1]
     return diffs
 
 
@@ -97,7 +97,8 @@ class MapsetSizeResource(ResourceManager):
 
     @swagger.doc({
         'tags': ['Process Chain Monitoring'],
-        'description': 'Get the mapset sizes of a resource. Minimum required user role: user.',
+        'description': 'Get the mapset sizes of a resource. '
+                       'Minimum required user role: user.',
         'parameters': [
             {
                 'name': 'user_id',
@@ -144,11 +145,10 @@ class MapsetSizeResource(ResourceManager):
                     message="Resource is not ready it is %s" % pc_status)),
                     400)
 
-            mapset_sizes = [proc['mapset_size']
-                for proc in pc_response_model['process_log']]
+            mapset_sizes = [
+                proc['mapset_size'] for proc in pc_response_model['process_log']]
 
-            return make_response(
-                jsonify(MapsetSizeResponseModel(
+            return make_response(jsonify(MapsetSizeResponseModel(
                 status="success", mapset_sizes=mapset_sizes)), http_code)
         else:
             return make_response(jsonify(SimpleResponseModel(
@@ -167,7 +167,8 @@ class MapsetSizeDiffResource(ResourceManager):
 
     @swagger.doc({
         'tags': ['Process Chain Monitoring'],
-        'description': 'Get the step-by-step mapset size differences of a resource. Minimum required user role: user.',
+        'description': 'Get the step-by-step mapset size differences of a '
+                       'resource. Minimum required user role: user.',
         'parameters': [
             {
                 'name': 'user_id',
@@ -214,12 +215,11 @@ class MapsetSizeDiffResource(ResourceManager):
                     message="Resource is not ready it is %s" % pc_status)),
                     400)
 
-            mapset_sizes = [proc['mapset_size']
-                for proc in pc_response_model['process_log']]
+            mapset_sizes = [
+                proc['mapset_size'] for proc in pc_response_model['process_log']]
             diffs = compute_mapset_size_diffs(mapset_sizes)
 
-            return make_response(
-                jsonify(MapsetSizeResponseModel(
+            return make_response(jsonify(MapsetSizeResponseModel(
                 status="success", mapset_sizes=diffs)), http_code)
         else:
             return make_response(jsonify(SimpleResponseModel(
@@ -256,7 +256,8 @@ class MaxMapsetSizeResource(ResourceManager):
 
     @swagger.doc({
         'tags': ['Process Chain Monitoring'],
-        'description': 'Get the maximum mapset size of a resource. Minimum required user role: user.',
+        'description': 'Get the maximum mapset size of a resource. '
+                       'Minimum required user role: user.',
         'parameters': [
             {
                 'name': 'user_id',
@@ -303,12 +304,11 @@ class MaxMapsetSizeResource(ResourceManager):
                     message="Resource is not ready it is %s" % pc_status)),
                     400)
 
-            mapset_sizes = [proc['mapset_size']
-                for proc in pc_response_model['process_log']]
+            mapset_sizes = [
+                proc['mapset_size'] for proc in pc_response_model['process_log']]
             max_mapset_size = max(mapset_sizes)
 
-            return make_response(
-                jsonify(MaxMapsetSizeResponseModel(
+            return make_response(jsonify(MaxMapsetSizeResponseModel(
                 status="success", max_mapset_size=max_mapset_size)), http_code)
         else:
             return make_response(jsonify(SimpleResponseModel(
@@ -327,7 +327,8 @@ class MapsetSizeRenderResource(ResourceManager):
 
     @swagger.doc({
         'tags': ['Process Chain Monitoring'],
-        'description': 'Render the mapset sizes of a resource. Minimum required user role: user.',
+        'description': 'Render the mapset sizes of a resource. '
+                       'Minimum required user role: user.',
         'parameters': [
             {
                 'name': 'user_id',
@@ -344,12 +345,13 @@ class MapsetSizeRenderResource(ResourceManager):
                 'type': 'string'
             }
         ],
-        'produces':["image/png"],
+        'produces': ["image/png"],
         'responses': {
             '200': {
                 'description': 'The PNG image'},
             '400': {
-                'description': 'The error message and a detailed log why rendering did not succeeded',
+                'description': 'The error message and a detailed log why '
+                               'rendering did not succeeded',
                 'schema': SimpleResponseModel
             }
         }
@@ -373,16 +375,15 @@ class MapsetSizeRenderResource(ResourceManager):
                     message="Resource is not ready it is %s" % pc_status)),
                     400)
 
-            mapset_sizes = [proc['mapset_size']
-                for proc in pc_response_model['process_log']]
-
+            mapset_sizes = [
+                proc['mapset_size'] for proc in pc_response_model['process_log']]
 
             y = np.array(mapset_sizes)
             x = np.array(list(range(1, len(mapset_sizes) + 1)))
             unit = "bytes"
             for new_unit in ['KB', 'MB', 'GB', 'TB']:
                 if max(y) > 1024.:
-                    y = y/1024.
+                    y = y / 1024.
                     unit = new_unit
                     print(new_unit)
                 else:
@@ -415,7 +416,8 @@ class MapsetSizeDiffRenderResource(ResourceManager):
 
     @swagger.doc({
         'tags': ['Process Chain Monitoring'],
-        'description': 'Render the step-by-step mapset size differences of a resource. Minimum required user role: user.',
+        'description': 'Render the step-by-step mapset size differences of a '
+                       'resource. Minimum required user role: user.',
         'parameters': [
             {
                 'name': 'user_id',
@@ -432,12 +434,13 @@ class MapsetSizeDiffRenderResource(ResourceManager):
                 'type': 'string'
             }
         ],
-        'produces':["image/png"],
+        'produces': ["image/png"],
         'responses': {
             '200': {
                 'description': 'The PNG image'},
             '400': {
-                'description': 'The error message and a detailed log why rendering did not succeeded',
+                'description': 'The error message and a detailed log why '
+                               'rendering did not succeeded',
                 'schema': SimpleResponseModel
             }
         }
@@ -461,8 +464,8 @@ class MapsetSizeDiffRenderResource(ResourceManager):
                     message="Resource is not ready it is %s" % pc_status)),
                     400)
 
-            mapset_sizes = [proc['mapset_size']
-                for proc in pc_response_model['process_log']]
+            mapset_sizes = [
+                proc['mapset_size'] for proc in pc_response_model['process_log']]
             diffs = compute_mapset_size_diffs(mapset_sizes)
 
             y = np.array(diffs)
@@ -470,7 +473,7 @@ class MapsetSizeDiffRenderResource(ResourceManager):
             unit = "bytes"
             for new_unit in ['KB', 'MB', 'GB', 'TB']:
                 if max(y) > 1024.:
-                    y = y/1024.
+                    y = y / 1024.
                     unit = new_unit
                     print(new_unit)
                 else:
@@ -479,7 +482,8 @@ class MapsetSizeDiffRenderResource(ResourceManager):
             # create png
             result_file = create_scatter_plot(
                 x, y, 'process chain steps', 'mapset size [%s]' % unit,
-                'Step-by-step mapset size differences of the resource\n%s' % resource_id)
+                'Step-by-step mapset size differences of the resource\n%s'
+                % resource_id)
 
             if result_file:
                 if os.path.isfile(result_file):

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -58,6 +58,14 @@ def create_scatter_plot(x, y, xlabel, ylabel, title):
     return result_file
 
 
+def compute_mapset_size_diffs(mapset_sizes):
+    diffs = [None] * len(mapset_sizes)
+    diffs[0] = mapset_sizes[0] # TODO not correct cause an empty mapset has also a size!
+    for i in range(1, len(mapset_sizes)):
+        diffs[i] = mapset_sizes[i] - mapset_sizes[i-1]
+    return diffs
+
+
 class MapsetSizeResponseModel(Schema):
     """Response schema for mapset sizes of a resource
     """
@@ -79,7 +87,7 @@ class MapsetSizeResponseModel(Schema):
 
 class MapsetSizeResource(ResourceManager):
     """
-    This class return the maximum mapset size of a resource
+    This class return the mapset sizes of a resource
     """
     def __init__(self):
 
@@ -88,7 +96,7 @@ class MapsetSizeResource(ResourceManager):
 
     @swagger.doc({
         'tags': ['Process Chain Monitoring'],
-        'description': 'Get the maximum mapset size of a resource. Minimum required user role: user.',
+        'description': 'Get the mapset sizes of a resource. Minimum required user role: user.',
         'parameters': [
             {
                 'name': 'user_id',
@@ -117,7 +125,7 @@ class MapsetSizeResource(ResourceManager):
         }
     })
     def get(self, user_id, resource_id):
-        """Get the maximum size of mapset of a resource."""
+        """Get the sizes of mapset of a resource."""
 
         ret = self.check_permissions(user_id=user_id)
         if ret:
@@ -141,6 +149,77 @@ class MapsetSizeResource(ResourceManager):
             return make_response(
                 jsonify(MapsetSizeResponseModel(
                 status="success", mapset_sizes=mapset_sizes)), http_code)
+        else:
+            return make_response(jsonify(SimpleResponseModel(
+                status="error",
+                message="Resource does not exist")), 400)
+
+
+class MapsetSizeDiffResource(ResourceManager):
+    """
+    This class return the mapset size differences of a resource
+    """
+    def __init__(self):
+
+        # Configuration
+        ResourceManager.__init__(self)
+
+    @swagger.doc({
+        'tags': ['Process Chain Monitoring'],
+        'description': 'Get the mapset size differences of a resource. Minimum required user role: user.',
+        'parameters': [
+            {
+                'name': 'user_id',
+                'description': 'The unique user name/id',
+                'required': True,
+                'in': 'path',
+                'type': 'string'
+            },
+            {
+                'name': 'resource_id',
+                'description': 'The id of the resource',
+                'required': True,
+                'in': 'path',
+                'type': 'string'
+            }
+        ],
+        'responses': {
+            '200': {
+                'description': 'The current state of the resource',
+                'schema': MapsetSizeResponseModel
+            },
+            '400': {
+                'description': 'The error message if the resource does not exists',
+                'schema': SimpleResponseModel
+            }
+        }
+    })
+    def get(self, user_id, resource_id):
+        """Get the size differences of mapset of a resource."""
+
+        ret = self.check_permissions(user_id=user_id)
+        if ret:
+            return ret
+
+        response_data = self.resource_logger.get(user_id, resource_id)
+
+        if response_data is not None:
+            http_code, pc_response_model = pickle.loads(response_data)
+
+            pc_status = pc_response_model['status']
+            if pc_status in ['accepted', 'running']:
+                return make_response(jsonify(SimpleResponseModel(
+                    status="error",
+                    message="Resource is not ready it is %s" % pc_status)),
+                    400)
+
+            mapset_sizes = [proc['mapset_size']
+                for proc in pc_response_model['process_log']]
+            diffs = compute_mapset_size_diffs(mapset_sizes)
+
+            return make_response(
+                jsonify(MapsetSizeResponseModel(
+                status="success", mapset_sizes=diffs)), http_code)
         else:
             return make_response(jsonify(SimpleResponseModel(
                 status="error",
@@ -247,7 +326,7 @@ class MapsetSizeRenderResource(ResourceManager):
 
     @swagger.doc({
         'tags': ['Process Chain Monitoring'],
-        'description': 'Get the maximum mapset size of a resource. Minimum required user role: user.',
+        'description': 'Render the mapset sizes of a resource. Minimum required user role: user.',
         'parameters': [
             {
                 'name': 'user_id',
@@ -298,6 +377,94 @@ class MapsetSizeRenderResource(ResourceManager):
 
 
             y = np.array(mapset_sizes)
+            x = np.array(list(range(1, len(mapset_sizes) + 1)))
+            unit = "bytes"
+            for new_unit in ['KB', 'MB', 'GB', 'TB']:
+                if max(y) > 1024.:
+                    y = y/1024.
+                    unit = new_unit
+                    print(new_unit)
+                else:
+                    break
+
+            # create png
+            result_file = create_scatter_plot(
+                x, y, 'process chain steps', 'mapset size [%s]' % unit,
+                'Mapset sizes of the resource\n%s' % resource_id)
+
+            if result_file:
+                if os.path.isfile(result_file):
+                    image = open(result_file, "rb").read()
+                    os.remove(result_file)
+                    return Response(image, mimetype='image/png')
+        else:
+            return make_response(jsonify(SimpleResponseModel(
+                status="error",
+                message="Resource does not exist")), 400)
+
+
+class MapsetSizeDiffRenderResource(ResourceManager):
+    """
+    This class renders the mapset size differences of a resource
+    """
+    def __init__(self):
+
+        # Configuration
+        ResourceManager.__init__(self)
+
+    @swagger.doc({
+        'tags': ['Process Chain Monitoring'],
+        'description': 'Render the mapset size differences of a resource. Minimum required user role: user.',
+        'parameters': [
+            {
+                'name': 'user_id',
+                'description': 'The unique user name/id',
+                'required': True,
+                'in': 'path',
+                'type': 'string'
+            },
+            {
+                'name': 'resource_id',
+                'description': 'The id of the resource',
+                'required': True,
+                'in': 'path',
+                'type': 'string'
+            }
+        ],
+        'produces':["image/png"],
+        'responses': {
+            '200': {
+                'description': 'The PNG image'},
+            '400': {
+                'description': 'The error message and a detailed log why rendering did not succeeded',
+                'schema': SimpleResponseModel
+            }
+        }
+    })
+    def get(self, user_id, resource_id):
+        """Render the mapset sizes of a resource."""
+
+        ret = self.check_permissions(user_id=user_id)
+        if ret:
+            return ret
+
+        response_data = self.resource_logger.get(user_id, resource_id)
+
+        if response_data is not None:
+            http_code, pc_response_model = pickle.loads(response_data)
+
+            pc_status = pc_response_model['status']
+            if pc_status in ['accepted', 'running']:
+                return make_response(jsonify(SimpleResponseModel(
+                    status="error",
+                    message="Resource is not ready it is %s" % pc_status)),
+                    400)
+
+            mapset_sizes = [proc['mapset_size']
+                for proc in pc_response_model['process_log']]
+            diffs = compute_mapset_size_diffs(mapset_sizes)
+
+            y = np.array(diffs)
             x = np.array(list(range(1, len(mapset_sizes) + 1)))
             unit = "bytes"
             for new_unit in ['KB', 'MB', 'GB', 'TB']:

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -4,7 +4,7 @@
 # performance processing of geographical data that uses GRASS GIS for
 # computational tasks. For details, see https://actinia.mundialis.de/
 #
-# Copyright (c) 2016-2018 Sören Gebbert and mundialis GmbH & Co. KG
+# Copyright (c) 2021 mundialis GmbH & Co. KG
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import os
 import pickle
-import tempfile
+from tempfile import NamedTemporaryFile
 from flask import jsonify, make_response, Response
 from flask_restful_swagger_2 import swagger, Schema
 
@@ -38,13 +38,13 @@ from .common.response_models import ProcessingResponseModel, SimpleResponseModel
 __license__ = "GPLv3"
 __author__ = "Anika Weinmann"
 __copyright__ = "Copyright 2021, mundialis GmbH & Co. KG"
-__maintainer__ = "mudnialis"
-__email__ = "info@mudnialis.de"
+__maintainer__ = "mundialis"
+__email__ = "info@mundialis.de"
 
 
 def create_scatter_plot(x, y, xlabel, ylabel, title):
 
-    result_file = tempfile.mktemp(suffix=".png")
+    plt.clf()
     plt.scatter(x, y, s=np.pi*5, c=(1,0,0))
     plt.title(title, fontsize=14)
     plt.xlabel(xlabel, fontsize=12)
@@ -54,8 +54,9 @@ def create_scatter_plot(x, y, xlabel, ylabel, title):
     y_len = len(y)
     step = y_up / 10
     plt.xticks(np.arange(1, len(y) + 1, step=1))
-    plt.savefig(result_file)
-    return result_file
+    with NamedTemporaryFile(suffix='.png', mode="wb", delete=False) as f:
+        plt.savefig(f)
+    return f.name
 
 
 def compute_mapset_size_diffs(mapset_sizes):

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -351,7 +351,7 @@ class MapsetSizeRenderResource(ResourceManager):
                 'description': 'The PNG image'},
             '400': {
                 'description': 'The error message and a detailed log why '
-                               'rendering did not succeeded',
+                               'rendering did not succeed',
                 'schema': SimpleResponseModel
             }
         }

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -478,7 +478,7 @@ class MapsetSizeDiffRenderResource(ResourceManager):
             # create png
             result_file = create_scatter_plot(
                 x, y, 'process chain steps', 'mapset size [%s]' % unit,
-                'Mapset sizes of the resource\n%s' % resource_id)
+                'Step-by-step mapset size differences of the resource\n%s' % resource_id)
 
             if result_file:
                 if os.path.isfile(result_file):

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -461,7 +461,7 @@ class MapsetSizeDiffRenderResource(ResourceManager):
             if pc_status in ['accepted', 'running']:
                 return make_response(jsonify(SimpleResponseModel(
                     status="error",
-                    message="Resource is not ready it is %s" % pc_status)),
+                    message="Resource is not ready, it is %s" % pc_status)),
                     400)
 
             mapset_sizes = [

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -280,7 +280,7 @@ class MaxMapsetSizeResource(ResourceManager):
                 'schema': MaxMapsetSizeResponseModel
             },
             '400': {
-                'description': 'The error message if the resource does not exists',
+                'description': 'The error message if the resource does not exist',
                 'schema': SimpleResponseModel
             }
         }

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -157,7 +157,7 @@ class MapsetSizeResource(ResourceManager):
 
 class MapsetSizeDiffResource(ResourceManager):
     """
-    This class returns the mapset size differences of a resource
+    This class returns the step-by-step mapset size differences of a resource
     """
     def __init__(self):
 
@@ -166,7 +166,7 @@ class MapsetSizeDiffResource(ResourceManager):
 
     @swagger.doc({
         'tags': ['Process Chain Monitoring'],
-        'description': 'Get the mapset size differences of a resource. Minimum required user role: user.',
+        'description': 'Get the step-by-step mapset size differences of a resource. Minimum required user role: user.',
         'parameters': [
             {
                 'name': 'user_id',
@@ -195,7 +195,7 @@ class MapsetSizeDiffResource(ResourceManager):
         }
     })
     def get(self, user_id, resource_id):
-        """Get the size differences of mapset of a resource."""
+        """Get the step-by-step mapset size differences of a resource."""
 
         ret = self.check_permissions(user_id=user_id)
         if ret:
@@ -405,7 +405,7 @@ class MapsetSizeRenderResource(ResourceManager):
 
 class MapsetSizeDiffRenderResource(ResourceManager):
     """
-    This class renders the mapset size differences of a resource
+    This class renders the step-by-step mapset size differences of a resource
     """
     def __init__(self):
 
@@ -414,7 +414,7 @@ class MapsetSizeDiffRenderResource(ResourceManager):
 
     @swagger.doc({
         'tags': ['Process Chain Monitoring'],
-        'description': 'Render the mapset size differences of a resource. Minimum required user role: user.',
+        'description': 'Render the step-by-step mapset size differences of a resource. Minimum required user role: user.',
         'parameters': [
             {
                 'name': 'user_id',
@@ -442,7 +442,7 @@ class MapsetSizeDiffRenderResource(ResourceManager):
         }
     })
     def get(self, user_id, resource_id):
-        """Render the mapset size differences of a resource."""
+        """Render the step-by-step mapset size differences of a resource."""
 
         ret = self.check_permissions(user_id=user_id)
         if ret:

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -24,9 +24,12 @@
 """
 Process Chain Monitoring
 """
-
+import matplotlib.pyplot as plt
+import numpy as np
+import os
 import pickle
-from flask import jsonify, make_response
+import tempfile
+from flask import jsonify, make_response, Response
 from flask_restful_swagger_2 import swagger, Schema
 
 from .resource_management import ResourceManager
@@ -37,6 +40,111 @@ __author__ = "Anika Weinmann"
 __copyright__ = "Copyright 2021, mundialis GmbH & Co. KG"
 __maintainer__ = "mudnialis"
 __email__ = "info@mudnialis.de"
+
+
+def create_scatter_plot(x, y, xlabel, ylabel, title):
+
+    result_file = tempfile.mktemp(suffix=".png")
+    plt.scatter(x, y, s=np.pi*5, c=(1,0,0))
+    plt.title(title, fontsize=14)
+    plt.xlabel(xlabel, fontsize=12)
+    plt.ylabel(ylabel, fontsize=12)
+    y_up = (max(y) + 9) // 10 * 10
+    plt.ylim(0, y_up)
+    y_len = len(y)
+    step = y_up / 10
+    plt.xticks(np.arange(1, len(y) + 1, step=1))
+    plt.savefig(result_file)
+    return result_file
+
+
+class MapsetSizeResponseModel(Schema):
+    """Response schema for mapset sizes of a resource
+    """
+    type = 'object'
+    properties = {
+        'status': {
+            'type': 'string',
+            'description': 'The status of the resource, values: success, error'
+        },
+        'mapset_sizes': {
+            'type': 'array',
+            'items': {"type": "integer"},
+            'description': 'The list of mapset sizes of a resource in bytes'
+        }
+    }
+    example = {"mapset_sizes": [29946, 29946], "status": "success"}
+    required = ["status", "mapset_sizes"]
+
+
+class MapsetSizeResource(ResourceManager):
+    """
+    This class return the maximum mapset size of a resource
+    """
+    def __init__(self):
+
+        # Configuration
+        ResourceManager.__init__(self)
+
+    @swagger.doc({
+        'tags': ['Process Chain Monitoring'],
+        'description': 'Get the maximum mapset size of a resource. Minimum required user role: user.',
+        'parameters': [
+            {
+                'name': 'user_id',
+                'description': 'The unique user name/id',
+                'required': True,
+                'in': 'path',
+                'type': 'string'
+            },
+            {
+                'name': 'resource_id',
+                'description': 'The id of the resource',
+                'required': True,
+                'in': 'path',
+                'type': 'string'
+            }
+        ],
+        'responses': {
+            '200': {
+                'description': 'The current state of the resource',
+                'schema': MapsetSizeResponseModel
+            },
+            '400': {
+                'description': 'The error message if the resource does not exists',
+                'schema': SimpleResponseModel
+            }
+        }
+    })
+    def get(self, user_id, resource_id):
+        """Get the maximum size of mapset of a resource."""
+
+        ret = self.check_permissions(user_id=user_id)
+        if ret:
+            return ret
+
+        response_data = self.resource_logger.get(user_id, resource_id)
+
+        if response_data is not None:
+            http_code, pc_response_model = pickle.loads(response_data)
+
+            pc_status = pc_response_model['status']
+            if pc_status in ['accepted', 'running']:
+                return make_response(jsonify(SimpleResponseModel(
+                    status="error",
+                    message="Resource is not ready it is %s" % pc_status)),
+                    400)
+
+            mapset_sizes = [proc['mapset_size']
+                for proc in pc_response_model['process_log']]
+
+            return make_response(
+                jsonify(MapsetSizeResponseModel(
+                status="success", mapset_sizes=mapset_sizes)), http_code)
+        else:
+            return make_response(jsonify(SimpleResponseModel(
+                status="error",
+                message="Resource does not exist")), 400)
 
 
 class MaxMapsetSizeResponseModel(Schema):
@@ -88,11 +196,11 @@ class MaxMapsetSizeResource(ResourceManager):
         'responses': {
             '200': {
                 'description': 'The current state of the resource',
-                'schema':MaxMapsetSizeResponseModel
+                'schema': MaxMapsetSizeResponseModel
             },
             '400': {
                 'description': 'The error message if the resource does not exists',
-                'schema':SimpleResponseModel
+                'schema': SimpleResponseModel
             }
         }
     })
@@ -122,6 +230,94 @@ class MaxMapsetSizeResource(ResourceManager):
             return make_response(
                 jsonify(MaxMapsetSizeResponseModel(
                 status="success", max_mapset_size=max_mapset_size)), http_code)
+        else:
+            return make_response(jsonify(SimpleResponseModel(
+                status="error",
+                message="Resource does not exist")), 400)
+
+
+class MapsetSizeRenderResource(ResourceManager):
+    """
+    This class renders the mapset sizes of a resource
+    """
+    def __init__(self):
+
+        # Configuration
+        ResourceManager.__init__(self)
+
+    @swagger.doc({
+        'tags': ['Process Chain Monitoring'],
+        'description': 'Get the maximum mapset size of a resource. Minimum required user role: user.',
+        'parameters': [
+            {
+                'name': 'user_id',
+                'description': 'The unique user name/id',
+                'required': True,
+                'in': 'path',
+                'type': 'string'
+            },
+            {
+                'name': 'resource_id',
+                'description': 'The id of the resource',
+                'required': True,
+                'in': 'path',
+                'type': 'string'
+            }
+        ],
+        'produces':["image/png"],
+        'responses': {
+            '200': {
+                'description': 'The PNG image'},
+            '400': {
+                'description': 'The error message and a detailed log why rendering did not succeeded',
+                'schema': SimpleResponseModel
+            }
+        }
+    })
+    def get(self, user_id, resource_id):
+        """Render the mapset sizes of a resource."""
+
+        ret = self.check_permissions(user_id=user_id)
+        if ret:
+            return ret
+
+        response_data = self.resource_logger.get(user_id, resource_id)
+
+        if response_data is not None:
+            http_code, pc_response_model = pickle.loads(response_data)
+
+            pc_status = pc_response_model['status']
+            if pc_status in ['accepted', 'running']:
+                return make_response(jsonify(SimpleResponseModel(
+                    status="error",
+                    message="Resource is not ready it is %s" % pc_status)),
+                    400)
+
+            mapset_sizes = [proc['mapset_size']
+                for proc in pc_response_model['process_log']]
+
+
+            y = np.array(mapset_sizes)
+            x = np.array(list(range(1, len(mapset_sizes) + 1)))
+            unit = "bytes"
+            for new_unit in ['KB', 'MB', 'GB', 'TB']:
+                if max(y) > 1024.:
+                    y = y/1024.
+                    unit = new_unit
+                    print(new_unit)
+                else:
+                    break
+
+            # create png
+            result_file = create_scatter_plot(
+                x, y, 'process chain steps', 'mapset size [%s]' % unit,
+                'Mapset sizes of the resource\n%s' % resource_id)
+
+            if result_file:
+                if os.path.isfile(result_file):
+                    image = open(result_file, "rb").read()
+                    os.remove(result_file)
+                    return Response(image, mimetype='image/png')
         else:
             return make_response(jsonify(SimpleResponseModel(
                 status="error",

--- a/src/actinia_core/resources/process_chain_monitoring.py
+++ b/src/actinia_core/resources/process_chain_monitoring.py
@@ -442,7 +442,7 @@ class MapsetSizeDiffRenderResource(ResourceManager):
         }
     })
     def get(self, user_id, resource_id):
-        """Render the mapset sizes of a resource."""
+        """Render the mapset size differences of a resource."""
 
         ret = self.check_permissions(user_id=user_id)
         if ret:


### PR DESCRIPTION
This adds the `mapset_size` in bytes to the `resource_log`.
E.g.:
```
...
process_log: [{
		executable: "r.mapcalc",
		mapset_size: 29946,
		parameter: [
			"expression=baum=5"
		],
		return_code: 0,
		run_time: 0.15045166015625,
		stderr: [
			""
		],
		stdout: ""
	}
],
...
```

Additional some monitoring endpoints of this new `mapset_size` is added (example is only 2 small `r.mapcalc`):

- /resources/{user_id}/{resource_id}/mapsetsizes: return the mapset sizes of a resource
  ```
  {
	mapset_sizes: [
		29946,
		29949
	],
	status: "success"
  }
  ```
- /resources/{user_id}/{resource_id}/mapsetsizes/max: return the maximum mapset size of a resource
  ```
  {
	max_mapset_size: 29949,
	status: "success"
   }
  ```
- /resources/{user_id}/{resource_id}/mapsetsizes/render: renders the mapset sizes of a resource
  
![image](https://user-images.githubusercontent.com/37300249/109319809-93104a80-784f-11eb-952e-0f8a09e4a236.png)

- /resources/{user_id}/{resource_id}/mapsetsizes/diffs: returns the mapset size differences of a resource
  ```
  {
	mapset_sizes: [
		29946,
		3
	],
	status: "success"
  }
  ```
- /resources/{user_id}/{resource_id}/mapsetsizes/diffs/render: renders the mapset size differences of a resource
![image](https://user-images.githubusercontent.com/37300249/109319723-796f0300-784f-11eb-9fd5-f49555effd29.png)
