### PR TITLE
Fix several misspelled words

### DIFF
--- a/src/actinia_core/resources/common/aws_sentinel_interface.py
+++ b/src/actinia_core/resources/common/aws_sentinel_interface.py
@@ -58,7 +58,7 @@ class AWSSentinel2AInterface(object):
 
         1. Transform the Sentinel ID into the path of the productInfo.json url that is required to get the tile urls
         2. Parse the productInfo.json file and extract the tile urls
-        3. Create the download links for each tile based ond each band
+        3. Create the download links for each tile based on each band
         4. Include the tileInfo.json, xml and preview url's
 
         Args:

--- a/src/actinia_core/resources/common/exceptions.py
+++ b/src/actinia_core/resources/common/exceptions.py
@@ -22,7 +22,7 @@
 #######
 
 """
-Actinia Core Exceptions that should be used in case an error occures that is related to the Actinia Core
+Actinia Core Exceptions that should be used in case an error occurs that is related to the Actinia Core
 functionality
 """
 

--- a/src/actinia_core/resources/common/geodata_download_importer.py
+++ b/src/actinia_core/resources/common/geodata_download_importer.py
@@ -83,7 +83,7 @@ class GeoDataDownloadImportSupport(object):
         """Setup the download cache.
 
         Check the download cache if the file already exists, to avoid redundant downloads.
-        Create the cahce if it does not exist and switch into the temporary directory.
+        Create the cache if it does not exist and switch into the temporary directory.
         """
 
         # Create the download cache directory if it does not exists

--- a/src/actinia_core/resources/common/google_satellite_bigquery_interface.py
+++ b/src/actinia_core/resources/common/google_satellite_bigquery_interface.py
@@ -508,15 +508,15 @@ class GoogleSatelliteBigQueryInterface(object):
                                       "Sentinel-2 download URL's. Error message: %s" % str(e))
 
     def _generate_sentinel2_footprint(self, base_url):
-        """Download the sentinel XML metadata and parse it for the footpring
+        """Download the sentinel XML metadata and parse it for the footprint
 
         Args:
             base_url: The google cloud storage base url of the required product_id
 
         Returns: a tuple of strings
             (str, str)
-            The first string is the footpring as GML code,
-            Teh second string the the metadata XML document
+            The first string is the footprint as GML code,
+            The second string the the metadata XML document
 
         """
 

--- a/src/actinia_core/resources/common/process_chain.py
+++ b/src/actinia_core/resources/common/process_chain.py
@@ -673,7 +673,7 @@ class ProcessChainConverter(object):
                 raise AsyncProcessError("Source specification is required in import definition")
 
             if entry["import_descr"]["type"] not in ["raster", "vector", "sentinel2", "landsat", "file", "postgis"]:
-                raise AsyncProcessError("Unkown type specification: %s" % entry["import_descr"]["type"])
+                raise AsyncProcessError("Unknown type specification: %s" % entry["import_descr"]["type"])
 
             # RASTER; VECTOR, FILE
             if entry["import_descr"]["type"].lower() == "raster" or \
@@ -881,7 +881,7 @@ class ProcessChainConverter(object):
 
             for input in module_descr["inputs"]:
 
-                # Add import description to the import ist
+                # Add import description to the import list
                 if "import_descr" in input:
                     self.import_descr_list.append(input)
 
@@ -889,7 +889,7 @@ class ProcessChainConverter(object):
                     raise AsyncProcessError("<value> is missing in input description of process id: %s" % id)
 
                 if "param" not in input:
-                    raise AsyncProcessError(" <param> is missing in input description of process id: %s" % id)
+                    raise AsyncProcessError("<param> is missing in input description of process id: %s" % id)
 
                 value = input["value"]
                 param = input["param"]

--- a/src/actinia_core/resources/common/redis_interface.py
+++ b/src/actinia_core/resources/common/redis_interface.py
@@ -55,7 +55,7 @@ def create_job_queues(host, port, num_of_queues):
     Args:
         host: The hostname of the redis server
         port: The port of the redis server
-        num_of_queues: The number fo queues that should be created
+        num_of_queues: The number of queues that should be created
 
     """
     # Redis work queue and connection

--- a/src/actinia_core/resources/common/sentinel_processing_library.py
+++ b/src/actinia_core/resources/common/sentinel_processing_library.py
@@ -110,7 +110,7 @@ class Sentinel2Processing(object):
         sentinel2 scene from the Google Cloud Storage.
 
         1. Query Google BogQuery to gather the scene information
-        2. Crate URL list of files that must be downloaded and copied to the download cache
+        2. Create URL list of files that must be downloaded and copied to the download cache
         3. Create the GML file that represents the footprint of the scene
         4. Check if the requested files exist
 
@@ -395,7 +395,7 @@ class Sentinel2Processing(object):
             temp_map_name = map_name + "_uncropped"
             cropped_input_file = input_file + ".vrt"
 
-            # Create a boundingbox around the footprint to avaoid
+            # Create a boundingbox around the footprint to avoid
             # the projection of the scene with unused values
             gdal_translate = "/usr/bin/gdal_translate"
             gdal_translate_params = list()

--- a/src/actinia_core/resources/common/user.py
+++ b/src/actinia_core/resources/common/user.py
@@ -88,7 +88,7 @@ class ActiniaUser(object):
             accessible_datasets (dict): Dict of location:mapset lists
             accessible_modules (list): A list of modules that are allowed to use
             cell_limit (int): Maximum number of cells to process
-            process_num_limit (int): The maximum number of processes the user is allowed to run in a singel chain
+            process_num_limit (int): The maximum number of processes the user is allowed to run in a single chain
             process_time_limit (int): The maximum number of seconds a user process is allowed to run
 
         """
@@ -667,7 +667,7 @@ class ActiniaUser(object):
             accessible_datasets (dict): The user role (admin, user, guest)
             accessible_modules (list): Dict of location:mapset lists
             cell_limit (int): Maximum number of cells to process
-            process_num_limit (int): The maximum number of processes the user is allowed to run in a singel chain
+            process_num_limit (int): The maximum number of processes the user is allowed to run in a single chain
             process_time_limit (int): The maximum number of seconds a user process is allowed to run
 
         Returns:

--- a/src/actinia_core/resources/ephemeral_custom_processing.py
+++ b/src/actinia_core/resources/ephemeral_custom_processing.py
@@ -113,7 +113,7 @@ class EphemeralCustomProcessing(EphemeralProcessing):
                                                    module_name=self.executable)
 
         if resp is not None:
-            raise AsyncProcessError("Executable <%s> is not suported" % self.executable)
+            raise AsyncProcessError("Executable <%s> is not supported" % self.executable)
 
         p = Process(exec_type="exec",
                          executable=self.executable,

--- a/src/actinia_core/resources/ephemeral_processing.py
+++ b/src/actinia_core/resources/ephemeral_processing.py
@@ -171,7 +171,7 @@ class EphemeralProcessing(object):
        e.g: /mount/groups/[user group]/locations/ECAD/PERMANENT -> /tmp/soeren_temp_gisdbase/ECAD/PERMANENT
        e.g: /mount/groups/[user group]/locations/ECAD/Temperature -> /tmp/soeren_temp_gisdbase/ECAD/Temperature
 
-    4. Set the GRASS GIS environmental variables to point ot the new gisdbase, location and PERMANENT maspet
+    4. Set the GRASS GIS environmental variables to point to the new gisdbase, location and PERMANENT maspet
 
     5. Create a new mapset with g.mapset in the temporary location directory
 
@@ -308,7 +308,7 @@ class EphemeralProcessing(object):
         self.webhook_finished = None  # The URL of a webhook that should be called after processing of a
         # process chain finished
         self.webhook_update = None  # The URL of a webhook that should be called for each status/progress update
-        self.webhook_auth = None  # The authentification for the webhook (base 64 decoded "username:password")
+        self.webhook_auth = None  # The authentication for the webhook (base 64 decoded "username:password")
 
     def _send_resource_update(self, message, results=None):
         """Create an HTTP response document and send it to the status database
@@ -1001,7 +1001,7 @@ class EphemeralProcessing(object):
 
         Check each poll the termination status of the resource.
         If the termination state is set True, terminate the current process
-        and raise an AsyncProcessTermination exception that must be catched
+        and raise an AsyncProcessTermination exception that must be caught
         by the run() method.
 
         Args:
@@ -1038,7 +1038,7 @@ class EphemeralProcessing(object):
 
         Check each poll the termination status of the resource.
         If the termination state is set True, terminate the current process
-        and raise an AsyncProcessTermination exception that must be catched
+        and raise an AsyncProcessTermination exception that must be caught
         by the run() method.
 
         By default the status of the running process is checked each 0.005 seconds.

--- a/src/actinia_core/resources/location_management.py
+++ b/src/actinia_core/resources/location_management.py
@@ -148,7 +148,7 @@ class ProjectionInfoModel(Schema):
 
 
 class LocationManagementResourceUser(ResourceBase):
-    """This class returns informations about a specific location
+    """This class returns information about a specific location
     """
 
     def __init__(self):

--- a/src/actinia_core/resources/persistent_processing.py
+++ b/src/actinia_core/resources/persistent_processing.py
@@ -49,7 +49,7 @@ __email__ = "soerengebbert@googlemail.com"
 
 DESCR = """Execute a user defined process chain in an existing mapset
 of the persistent user database or in a new mapset that will be
-created by this reuqest in the persistent user database.
+created by this request in the persistent user database.
 
 The process chain is executed asynchronously. The provided status URL
 in the response must be polled to gain information about the processing
@@ -328,7 +328,7 @@ class PersistentProcessing(EphemeralProcessing):
             else:
                 raise AsyncProcessError("Unable to access global location <%s>" % self.location_name)
 
-        # Always check if the targte mapset already exists and set the flag accordingly
+        # Always check if the target mapset already exists and set the flag accordingly
         if os.path.exists(self.user_location_path) and \
                 os.path.isdir(self.user_location_path) and \
                         os.access(self.user_location_path, os.R_OK | os.X_OK | os.W_OK) is True:
@@ -402,7 +402,7 @@ class PersistentProcessing(EphemeralProcessing):
         self.message_logger.info("Copy source mapset <%s> content "
                                  "into the target mapset <%s>" % (source_mapset, target_mapset))
 
-        # Raster adn vector directories
+        # Raster and vector directories
         directories = ["cell", "misc", "fcell",
                        "cats", "cellhd",
                        "cell_misc", "colr", "colr2",
@@ -578,7 +578,8 @@ class PersistentProcessing(EphemeralProcessing):
             self._create_grass_environment(grass_data_base=self.temp_grass_data_base,
                                            mapset_name="PERMANENT")
 
-            # Create the temporary mapset wth the same name as the targte mapset and switch into it
+            # Create the temporary mapset with the same name as the target 
+            # mapset and switch into it
             self._create_temporary_mapset(temp_mapset_name=self.target_mapset_name)
             self.temp_mapset_name = self.target_mapset_name
         else:

--- a/src/actinia_core/resources/renderer_base.py
+++ b/src/actinia_core/resources/renderer_base.py
@@ -99,7 +99,7 @@ class RendererBaseResource(ResourceBase):
             e : for east
             w : for west
             width : for the image width
-            heigt : for the image height
+            height : for the image height
             start_time : start time for STRDS where selection
             end_time : end time for STRDS where selection
 

--- a/src/actinia_core/resources/resource_management.py
+++ b/src/actinia_core/resources/resource_management.py
@@ -85,7 +85,7 @@ class ResourceManagerBase(Resource):
             user_id:
 
         Returns:
-            None if permissions granted, a error response if permissions are not fullfilled
+            None if permissions granted, a error response if permissions are not fulfilled
 
         """
         # Superuser are allowed to do everything

--- a/src/actinia_core/resources/strds_management.py
+++ b/src/actinia_core/resources/strds_management.py
@@ -339,7 +339,7 @@ class STRDSInfoResponseModel(ProcessingResponseModel):
 
 recursive_parser = reqparse.RequestParser()
 recursive_parser.add_argument('recursive', type=bool, help='Set True to recursively remove '
-                                                           'the STRDS and all registred raster '
+                                                           'the STRDS and all registered raster '
                                                            'map layer', location='args')
 
 

--- a/src/actinia_core/resources/user_auth.py
+++ b/src/actinia_core/resources/user_auth.py
@@ -154,7 +154,7 @@ def check_user_permissions(f):
     This decorator function verifies the user permissions
     to access locations, mapsets and modules.
 
-    The function arguments are checked if they conatin:
+    The function arguments are checked if they contain:
 
         - location_name
         - mapset_name


### PR DESCRIPTION
These were found with [`codespell`](https://github.com/codespell-project/codespell).

I was unsure of what to do with `Gigibit` in the following two cases:

* https://github.com/mundialis/actinia_core/blob/master/src/actinia_core/resources/common/config.py#L86
* https://github.com/mundialis/actinia_core/blob/master/src/actinia_core/resources/common/config.py#L130

Are we talking about `Gigabyte` or `Gigabit`? Can surely be fixed in a follow-up request.

Please review.