### PR TITLE
Use non-root user for prod docker example

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -143,13 +143,13 @@ docker-compose -f docker-compose-prod.yml up -d
 Then actinia runs at 'http://127.0.0.1:8088' and depending on your server settings might be accessible from outside. Because of this the start.sh is overwritten to not create any user to avoid security vulnarability. You will have to use a clean redis database to avoid stored actinia credentials from previous runs. You have to create the user by yourself by using the build-in actinia-user cli. __Please change below username (-u) and password (-w)__:
 ```
 # list help about the cli tool:
-docker-compose -f docker-compose-prod.yml exec actinia-core \
+docker-compose -f docker-compose-prod.yml exec actinia \
     actinia-user --help
 
 # create a user and grant permissions to mapsets:
-docker-compose -f docker-compose-prod.yml exec actinia-core \
+docker-compose -f docker-compose-prod.yml exec actinia \
     actinia-user create -u actinia-core -w actinia-core -r user -g user -c 100000000 -n 1000 -t 6000
-docker-compose -f docker-compose-prod.yml exec actinia-core \
+docker-compose -f docker-compose-prod.yml exec actinia \
     actinia-user update -u actinia-core -d nc_spm_08/PERMANENT
 ```
 Read more about user roles here: https://actinia.mundialis.de/tutorial/actinia_concepts.html#user-user-roles-and-user-groups

--- a/docker/actinia-core-prod/Dockerfile
+++ b/docker/actinia-core-prod/Dockerfile
@@ -1,14 +1,14 @@
 FROM mundialis/actinia-core:0.99
 
-# Copy actinia config file and start scripts
 COPY actinia.cfg /etc/default/actinia
 COPY start.sh /src/start.sh
 
-WORKDIR /src/actinia_core
-RUN python3 setup.py install
+# Let actinia run as non-root user
+ARG USER_ID=1000
+ARG GROUP_ID=1000
 
-EXPOSE 8088
-EXPOSE 9191
+RUN addgroup -g $GROUP_ID user
+RUN adduser -D -g '' -u $USER_ID -G user user
+RUN chown -R user:user /src/
 
-ENTRYPOINT ["/bin/bash"]
-CMD ["/src/start.sh"]
+USER user

--- a/docker/docker-compose-prod.yml
+++ b/docker/docker-compose-prod.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
 
-  actinia-core:
+  actinia:
     build:
       context: actinia-core-prod/
     volumes:


### PR DESCRIPTION
This PR
* lets actinia run as non-root user in prod docker example
* syncs prod docker setup to dev
* removes duplicated lines which are already included in parent image