### PR TITLE
Webhook auth

### DIFF
--- a/src/actinia_core/resources/common/response_models.py
+++ b/src/actinia_core/resources/common/response_models.py
@@ -1180,6 +1180,14 @@ def create_response_from_model(response_model_class=ProcessingResponseModel,
     # if issubclass(response_model_class, ProcessingResponseModel) is False:
     #    raise IOError
 
+    # if webhook auth is given set pw to XXX
+    for i in range(len(process_chain_list)):
+        if ('webhooks' in process_chain_list[i]
+                and 'auth' in process_chain_list[i]['webhooks']):
+            webhook_auth = process_chain_list[i]['webhooks']['auth']
+            process_chain_list[i]['webhooks']['auth'] = \
+                f"{webhook_auth.split(':')[0]}:XXX"
+
     resp_dict = response_model_class(status=status,
                                      user_id=user_id,
                                      resource_id=resource_id,


### PR DESCRIPTION
This changes replaces the webhook password in the actinia answer with `XXX`.
E.g.:
```
{
  "accept_datetime": "2021-03-26 12:52:23.262368",
  "accept_timestamp": 1616763143.2623677,
  "api_info": {
    "endpoint": "asyncephemeralexportresource",
    "method": "POST",
    "path": "/api/v1/locations/nc_spm_08/processing_async_export",
    "request_url": "http://127.0.0.1:8088/api/v1/locations/nc_spm_08/processing_async_export"
  },
  "datetime": "2021-03-26 12:52:38.793064",
  "http_code": 200,
  "message": "Processing successfully finished",
  "process_chain_list": [
    {
      "list": [
      ...
      ],
      "version": "1",
      "webhooks": {
        "auth": "test_user:XXX",
        "finished": "http://0.0.0.0:5005/webhook/finished",
        "update": "http://0.0.0.0:5005/webhook/update"
      }
    }
  ],
  "process_log": [ ... ],
  "process_results": { ...  },
  "progress": { ... },
  "resource_id": "resource_id-735bc988-b134-43c6-bb3f-f4eb6c9ad999",
  "status": "finished",
  "time_delta": 15.530728578567505,
  "timestamp": 1616763158.7930524,
  "urls": { ... },
  "user_id": "actinia-gdi"
}
```