### PR TITLE
raise AsyncProcessError if mapset-lock to be checked does not exist

### DIFF
--- a/src/actinia_core/resources/mapset_management.py
+++ b/src/actinia_core/resources/mapset_management.py
@@ -649,8 +649,16 @@ class PersistentGetMapsetLock(PersistentProcessing):
 
     def _execute(self):
         self._setup()
-        self.module_results = self.lock_interface.get(self.target_mapset_lock_id)
-        self.finish_message = "Mapset lock state: %s" % str(self.module_results)
+        exists = self._check_mapset(self.mapset_name)
+        if exists is False:
+            raise AsyncProcessError(
+                "Invalid mapset <%s> in location <%s>"
+                % (self.mapset_name, self.location_name))
+        else:
+            self.module_results = self.lock_interface.get(
+                self.target_mapset_lock_id)
+            self.finish_message = "Mapset lock state: %s" % str(
+                self.module_results)
 
 
 def lock_mapset(*args):

--- a/src/actinia_core/resources/mapset_management.py
+++ b/src/actinia_core/resources/mapset_management.py
@@ -649,10 +649,11 @@ class PersistentGetMapsetLock(PersistentProcessing):
 
     def _execute(self):
         self._setup()
-        exists = self._check_mapset(self.mapset_name)
-        if exists is False:
+        self._check_target_mapset_exists()
+        if self.target_mapset_exists is False:
             raise AsyncProcessError(
-                "Invalid mapset <%s> in location <%s>"
+                ("Unable to get lock status of mapset <%s> in location <%s>:"
+                 " Mapset does not exist")
                 % (self.mapset_name, self.location_name))
         else:
             self.module_results = self.lock_interface.get(
@@ -705,7 +706,13 @@ class PersistentMapsetUnlocker(PersistentProcessing):
 
     def _execute(self):
         self._setup()
-        self.lock_interface.unlock(self.target_mapset_lock_id)
-
-        self.finish_message = \
-            "Mapset <%s> successfully unlocked" % self.target_mapset_name
+        self._check_target_mapset_exists()
+        if self.target_mapset_exists is False:
+            raise AsyncProcessError(
+                ("Unable to unlock mapset <%s> in location <%s>:"
+                 " Mapset does not exist")
+                % (self.mapset_name, self.location_name))
+        else:
+            self.lock_interface.unlock(self.target_mapset_lock_id)
+            self.finish_message = \
+                "Mapset <%s> successfully unlocked" % self.target_mapset_name

--- a/src/actinia_core/resources/persistent_processing.py
+++ b/src/actinia_core/resources/persistent_processing.py
@@ -377,7 +377,6 @@ class PersistentProcessing(EphemeralProcessing):
                     os.access(
                         self.global_location_path,
                         os.R_OK | os.X_OK | os.W_OK) is True:
-
                 self.orig_mapset_path = os.path.join(self.global_location_path, mapset)
 
                 if os.path.exists(self.orig_mapset_path) is True:
@@ -417,6 +416,23 @@ class PersistentProcessing(EphemeralProcessing):
 
         return mapset_exists
 
+    def _check_target_mapset_exists(self):
+        """Check if the target mapset exists
+
+        This method will check if the target mapset exists in the global and user
+        location.
+        If the mapset is in the global database, then an AsyncProcessError will
+        be raised, since global mapsets can not be modified.
+
+        This method sets in case of success:
+
+            self.target_mapset_exists = True/False
+
+        Raises:
+            AsyncProcessError
+        """
+        self.target_mapset_exists = self._check_mapset(self.target_mapset_name)
+
     def _check_lock_target_mapset(self):
         """Check if the target mapset exists and lock it, then lock the temporary mapset
 
@@ -434,7 +450,7 @@ class PersistentProcessing(EphemeralProcessing):
             AsyncProcessError
 
         """
-        self.target_mapset_exists = self._check_mapset(self.target_mapset_name)
+        self._check_target_mapset_exists()
         self._lock_target_mapset()
 
     def _lock_target_mapset(self):

--- a/tests/test_mapset_management.py
+++ b/tests/test_mapset_management.py
@@ -197,8 +197,8 @@ class MapsetTestCase(ActiniaResourceTestCaseBase):
         self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
         self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
-        lock_status = json_load(rv.data)["process_results"]
-        self.assertFalse(lock_status)
+        # lock_status = json_load(rv.data)["process_results"]
+        # self.assertFalse(lock_status)
 
         # Lock mapset
         rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset_2/lock',

--- a/tests/test_mapset_management.py
+++ b/tests/test_mapset_management.py
@@ -211,7 +211,7 @@ class MapsetTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.delete(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset_2/lock',
                                 headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
         self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
 

--- a/tests/test_mapset_management.py
+++ b/tests/test_mapset_management.py
@@ -194,7 +194,7 @@ class MapsetTestCase(ActiniaResourceTestCaseBase):
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets/test_mapset_2/lock',
                               headers=self.admin_auth_header)
         print(rv.data)
-        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        self.assertEqual(rv.status_code, 400, "HTML status code is wrong %i" % rv.status_code)
         self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
 
         lock_status = json_load(rv.data)["process_results"]


### PR DESCRIPTION
When the `api/v1/locations/<location>/mapsets/<mapsets>/lock` endpoint is used to check whether a mapset is locked, the process is successful and the actinia response contains
```
[...]  
"message": "Mapset lock state: False",
"process_chain_list": [],
"process_log": [],
"process_results": false,
[...]
```
even if the mapset does not exist. With this PR, an `AsyncProcessError` is raised if the combination of location and mapset to be checked for a lock does not exist. In case *not* raising an error is a desired behaviour, there might be another option to let the user know the mapset does not exist, e.g. by providing a different `self.finish_message`. 
 