### PR TITLE
Alpine Docker: update to snap 8.0.3

### DIFF
--- a/docker/actinia-core-alpine/Dockerfile
+++ b/docker/actinia-core-alpine/Dockerfile
@@ -1,5 +1,5 @@
 FROM mundialis/grass-py3-pdal:stable-alpine as grass
-FROM mundialis/esa-snap:s1tbx-8.0.1 as snap
+FROM mundialis/esa-snap:s1tbx-8.0.3 as snap
 FROM mundialis/actinia-core:alpine-build-pkgs_v7 as build
 
 LABEL authors="Carmen Tawalika,Anika Bettge,Markus Neteler,Sören Gebbert"


### PR DESCRIPTION
SNAP 8.0.3 was released on 12 March 2021 and includes a fix for a wrong default url for orbit file retrieval (https://forum.step.esa.int/t/orbit-file-timeout-march-2021/28621/94). Local build and testing proved that Orbit File retrieval and application works fine with the new image `mundialis/esa-snap:s1tbx-8.0.3`