### PR TITLE
rename master to main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '33 6 * * 2'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Types of changes
 
 
 ## [Unreleased]
-TODO https://github.com/mundialis/actinia_core/compare/0.99.28...master
+TODO https://github.com/mundialis/actinia_core/compare/0.99.29...main
 
 ## [0.99.X] - YYYY-MM-DD
 released from <branch>\

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The full API documentation is available here: https://actinia.mundialis.de/api_d
 ## actinia command execution - actinia shell
 
 There is also an option to interactively control actinia. For details,
-see [here](https://github.com/mundialis/actinia_core/tree/master/scripts).
+see [here](https://github.com/mundialis/actinia_core/tree/main/scripts).
 
 ## Installation
 

--- a/logging.md
+++ b/logging.md
@@ -37,7 +37,7 @@ The `log_interface`s `fluentd` and `stdout` are mutually exclusive, while actini
  log to file with configured formatter and log level `CRITICAL`.
 
  For more information, see
- https://github.com/mundialis/actinia_core/blob/master/src/actinia_core/resources/common/config.py#L132.
+ https://github.com/mundialis/actinia_core/blob/main/src/actinia_core/resources/common/config.py#L132.
 
 
 ### Dev / Debug Hints


### PR DESCRIPTION
As the default branch was renamed from `master` to `main`, this PR changes references in the code.