### PR TITLE
make better use of cache for test-Dockerimage

### DIFF
--- a/docker/actinia-core-tests/Dockerfile
+++ b/docker/actinia-core-tests/Dockerfile
@@ -3,40 +3,17 @@ FROM mundialis/actinia-core:0.99.26 as actinia_test
 LABEL authors="Carmen Tawalika,Anika Weinmann"
 LABEL maintainer="tawalika@mundialis.de,weinmann@mundialis.de"
 
-COPY . /src/actinia_core
-WORKDIR /src/actinia_core
-
-# uninstall actinia core from FROM-image
-RUN pip3 uninstall actinia-core -y
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
-
-# Duplicate install actinia_core requirements. They are already wheels in
-# /build folder, keep to check match of required packages
-COPY requirements.txt /src/requirements.txt
-RUN rm -rf /build && \
-  python3 setup.py sdist bdist_wheel -d /build
-# Install actinia-core
-RUN pip3 install /build/*
-RUN pip3 install -r /src/requirements.txt
-
-# needed files for test
-COPY tests_with_redis.sh tests_with_redis.sh
-COPY Makefile Makefile
-RUN chmod a+x tests_with_redis.sh
-
-# set config for test
-COPY docker/actinia-core-alpine/actinia.cfg /etc/default/actinia
-COPY docker/actinia-core-tests/actinia-test.cfg /etc/default/actinia_test
 ENV ACTINIA_CUSTOM_TEST_CFG /etc/default/actinia_test
 # TODO do not set DEFAULT_CONFIG_PATH if this is fixed
 ENV DEFAULT_CONFIG_PATH /etc/default/actinia_test
 
-# copy tests inside docker
-COPY tests tests
-
 # install things only for tests
 RUN apk add redis
 RUN pip3 install iniconfig colorlog
+
+# uninstall actinia core from FROM-image
+RUN pip3 uninstall actinia-core -y
 
 # add data for tests
 RUN wget --quiet https://grass.osgeo.org/sampledata/north_carolina/nc_spm_08_micro.zip && \
@@ -50,7 +27,22 @@ RUN wget --quiet https://grass.osgeo.org/sampledata/north_carolina/nc_spm_mapset
   mv  modis_lst /actinia_core/grassdb/nc_spm_08/modis_lst
 RUN chown -R 1001:1001 /actinia_core/grassdb/nc_spm_08/modis_lst && chmod -R g+w /actinia_core/grassdb/nc_spm_08/modis_lst
 
+# copy needed files and configs for test
+COPY docker/actinia-core-alpine/actinia.cfg /etc/default/actinia
+COPY docker/actinia-core-tests/actinia-test.cfg /etc/default/actinia_test
+COPY Makefile Makefile
+COPY tests_with_redis.sh tests_with_redis.sh
+RUN chmod a+x tests_with_redis.sh
+
+COPY requirements.txt /src/requirements.txt
+RUN pip3 install -r /src/requirements.txt
+
 # TODO: Postgres for tests
-# useing tests/data/poly.gpkg
+# using tests/data/poly.gpkg
+
+COPY . /src/actinia_core
+WORKDIR /src/actinia_core
+
+RUN make install
 
 RUN make test


### PR DESCRIPTION
To run tests for local changes, it is more nice to have shorter time to execute tests. Therefore the copy of code which might have changes was moved to end of Dockerfile for better use of cache and therefore shorter build times.