### PR TITLE
Fix docker test permissions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -52,6 +52,9 @@ sudo sysctl -w vm.max_map_count=262144
 
 <a id="local-dev-setup"></a>
 # Local dev-setup with docker
+
+__If not stated otherwise, you need to be in folder `actinia_core/docker`__
+
 To overwrite default config and uninstall actinia-core to use local source code, build a Dockerimage with the docker-compose-dev.yml file:
 ```
 docker-compose -f docker-compose-dev.yml build
@@ -68,6 +71,13 @@ For debugging or if you need to start the wsgi server regularly during developme
 ```
 python3 setup.py install
 gunicorn -b 0.0.0.0:8088 -w 1 --access-logfile=- -k gthread actinia_core.main:flask_app
+
+```
+To test your local changes, you best use the Test Dockerimage:
+```
+# changing directory is necessary to have the correct build context
+cd ..
+docker build -f docker/actinia-core-tests/Dockerfile -t actinia-test .
 ```
 
 ## Local dev-setup for actinia-core plugins

--- a/docker/actinia-core-tests/Dockerfile
+++ b/docker/actinia-core-tests/Dockerfile
@@ -30,9 +30,6 @@ RUN chown -R 1001:1001 /actinia_core/grassdb/nc_spm_08/modis_lst && chmod -R g+w
 # copy needed files and configs for test
 COPY docker/actinia-core-alpine/actinia.cfg /etc/default/actinia
 COPY docker/actinia-core-tests/actinia-test.cfg /etc/default/actinia_test
-COPY Makefile Makefile
-COPY tests_with_redis.sh tests_with_redis.sh
-RUN chmod a+x tests_with_redis.sh
 
 COPY requirements.txt /src/requirements.txt
 RUN pip3 install -r /src/requirements.txt
@@ -42,6 +39,7 @@ RUN pip3 install -r /src/requirements.txt
 
 COPY . /src/actinia_core
 WORKDIR /src/actinia_core
+RUN chmod a+x tests_with_redis.sh
 
 RUN make install
 


### PR DESCRIPTION
With current docker test setup, the following error appears:
```
Step 24/24 : RUN make test
 ---> Running in b9d599c55e6d
./tests_with_redis.sh
make: ./tests_with_redis.sh: Permission denied
make: *** [Makefile:22: test] Error 127
The command '/bin/sh -c make test' returned a non-zero code: 2
```
The permissions of `tests_with_redis.sh` were overwritten by a new complete copy of the code. This PR updates the permissions after the complete copy and removes duplicate copied files.

Additionally, the README was updated to explain how to run tests locally.