### PR TITLE
update docker readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -80,6 +80,8 @@ To test your local changes, you best use the Test Dockerimage:
 # changing directory is necessary to have the correct build context
 (cd .. && docker build -f docker/actinia-core-tests/Dockerfile -t actinia-test .)
 ```
+To dive deeper into testing + development, see the [test README](https://github.com/mundialis/actinia_core/blob/main/tests/README.md)
+
 To lint your local changes, run
 ```
 (cd ../src && flake8 --config=../.flake8 --count --statistics --show-source --jobs=$(nproc) .)

--- a/docker/README.md
+++ b/docker/README.md
@@ -78,9 +78,13 @@ gunicorn -b 0.0.0.0:8088 -w 1 --access-logfile=- -k gthread actinia_core.main:fl
 To test your local changes, you best use the Test Dockerimage:
 ```
 # changing directory is necessary to have the correct build context
-cd ..
-docker build -f docker/actinia-core-tests/Dockerfile -t actinia-test .
+(cd .. && docker build -f docker/actinia-core-tests/Dockerfile -t actinia-test .)
 ```
+To lint your local changes, run
+```
+(cd ../src && flake8 --config=../.flake8 --count --statistics --show-source --jobs=$(nproc) .)
+```
+
 
 ## Local dev-setup for actinia-core plugins
 To also integrate dev setup for actinia-core plugins


### PR DESCRIPTION
With these changes, it is possible to run tests and lint locally from the same folder where the dev setup is started from. This way, after local changes, it is just these two lines to be able to test and lint before commit and push.