### PR TITLE
Add bandref to RasterInfoModel

### DIFF
--- a/src/actinia_core/models/openapi/raster_layer.py
+++ b/src/actinia_core/models/openapi/raster_layer.py
@@ -66,7 +66,8 @@ class RasterInfoModel(Schema):
         'south': {'type': 'string'},
         'timestamp': {'type': 'string'},
         'title': {'type': 'string'},
-        'west': {'type': 'string'}
+        'west': {'type': 'string'},
+        'bandref': {'type': 'string'}
     }
     example = {
         "cells": "2025000",


### PR DESCRIPTION
In GRASS GIS, `r.info -gre` now adds a new parameter `bandref`. As this was not included in the `RasterInfoModel`, requesting the `RasterLayerResource` leaded to an error:

```
exception": {
"message": "The model \"RasterInfoModel\" does not have an attribute \"bandref\"",
"traceback": [
"  File \"/usr/lib/python3.8/site-packages/actinia_core/rest/ephemeral_processing.py\", line 1732, in run\n    self._execute()\n",
"  File \"/usr/lib/python3.8/site-packages/actinia_core/rest/raster_layer.py\", line 314, in _execute\n    self.module_results = RasterInfoModel(**raster_info)\n",
"  File \"/usr/lib/python3.8/site-packages/flask_restful_swagger_2/__init__.py\", line 336, in __init__\n    raise ValueError(\n"
],
"type": "<class 'ValueError'>"
},
```

This PR adds the missing parameter to the model.

Tested with GRASS GIS 7.8 as well, so if `r.info -gre` does not return `bandref`, it is simply left out and response is successful.