### PR TITLE
Prevent duplicate workflow run for release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ on:
     tags: ['*.*.*']
     paths-ignore: ['docs/**']
   release:
-    types: [published, created]
+    types: [published]
 
 env:
     # Additionally mentioned in docker-sha-release-latest


### PR DESCRIPTION
Currently, GHA for docker builds is triggered for releases when they are created and published. This makes sense, when pre-releases are created but not in our case. This PR reduces the trigger to the creation of a release.