### PR TITLE
Add json to stdoutParser options

### DIFF
--- a/src/actinia_core/models/process_chain.py
+++ b/src/actinia_core/models/process_chain.py
@@ -246,7 +246,7 @@ class StdoutParser(Schema):
                               'parsed output in the result dictionary.'},
         'format': {'type': 'string',
                    'description': 'The stdout format to be parsed.',
-                   'enum': ['table', 'list', 'kv']},
+                   'enum': ['table', 'list', 'kv', 'json']},
         'delimiter': {'type': 'string',
                       'description': 'The delimiter that should be used to parse table,'
                                      ' list and key/value module output. Many GRASS '

--- a/src/actinia_core/rest/ephemeral_processing.py
+++ b/src/actinia_core/rest/ephemeral_processing.py
@@ -25,7 +25,6 @@
 Base class for asynchronous processing
 """
 
-import json
 import math
 import os
 import pickle

--- a/src/actinia_core/rest/ephemeral_processing.py
+++ b/src/actinia_core/rest/ephemeral_processing.py
@@ -25,6 +25,7 @@
 Base class for asynchronous processing
 """
 
+import json
 import math
 import os
 import pickle
@@ -1675,6 +1676,11 @@ class EphemeralProcessing(object):
                         row = row.strip()
                         key, value = row.split(delimiter, 1)
                         result[key.strip()] = value.strip()
+                elif "json" in format:
+                    try:
+                        result = json.loads(stdout)
+                    except Exception:
+                        result = stdout
                 else:
                     raise AsyncProcessError("Wrong stdout parser format")
 


### PR DESCRIPTION
Before this PR, STDOUT from GRASS GIS addons could be parsed as table, list or key-value-pairs. To add a JSON output to the module from a process chain and the result looked like this (e.g. with type list):

```
        {
            "module": "m.dummy.birds",
            "id": "m_dummy_birds_1",
            "inputs":[
                {"param": "test", "value": "true"}
            ],
            "stdout": {"id": "my_output", "format": "list", "delimiter": ","}
        }
```

```
  "process_results": {
    "my_output": [
      "{",
      "\"birds\": [",
      "{",
      "\"id\": \"1\",",
      "\"scientific\": \"Euphagus cyanocephalus\",",
      "\"english\": \"Brewer's Blackbird\",",
      "\"french\": \"Quiscale de Brewer\",",
      "\"family\": \"Icteridae\"",
      "},",
      "{",
      "\"id\": \"2\",",
      "\"scientific\": \"Euphagus cyanocephalus\",",
      "\"english\": \"Brewer's Blackbird\",",
      "\"french\": \"Quiscale de Brewer\",",
      "\"family\": \"Icteridae\"",
      "}",
      "]",
      "}"
    ]
  },
...
```
now with this PR, valid json output is possible and can be parsed afterwards:
```
        {
            "module": "m.dummy.birds",
            "id": "m_dummy_birds_1",
            "inputs":[
                {"param": "test", "value": "true"}
            ],
            "stdout": {"id": "my_output", "format": "json", "delimiter": ","}
        }
```
```
  "process_results": {
    "my_output": {
      "birds": [
        {
          "english": "Brewer's Blackbird",
          "family": "Icteridae",
          "french": "Quiscale de Brewer",
          "id": "1",
          "scientific": "Euphagus cyanocephalus"
        },
        {
          "english": "Brewer's Blackbird",
          "family": "Icteridae",
          "french": "Quiscale de Brewer",
          "id": "2",
          "scientific": "Euphagus cyanocephalus"
        }
      ]
    }
  },
...
```