### PR TITLE
Enhance json output

### DIFF
--- a/src/actinia_core/rest/ephemeral_processing.py
+++ b/src/actinia_core/rest/ephemeral_processing.py
@@ -1679,7 +1679,7 @@ class EphemeralProcessing(object):
                     result = None
                     try:
                         result = {i[0]: i[1] for i in [
-                            entry.split('=') for entry in
+                            entry.split(delimiter, 1) for entry in
                             stdout.strip('\n').split('\n')]
                         }
                     except Exception:

--- a/src/actinia_core/rest/ephemeral_processing.py
+++ b/src/actinia_core/rest/ephemeral_processing.py
@@ -1676,10 +1676,20 @@ class EphemeralProcessing(object):
                         key, value = row.split(delimiter, 1)
                         result[key.strip()] = value.strip()
                 elif "json" in format:
+                    result = None
                     try:
-                        result = json.loads(stdout)
+                        result = {i[0]: i[1] for i in [
+                            entry.split('=') for entry in
+                            stdout.strip('\n').split('\n')]
+                        }
                     except Exception:
-                        result = stdout
+                        try:
+                            result = json.loads(stdout)
+                        except Exception:
+                            pass
+                    finally:
+                        if not result:
+                            result = stdout
                 else:
                     raise AsyncProcessError("Wrong stdout parser format")
 


### PR DESCRIPTION
This PR allows STDOUT output in JSON format for normal GRASS GIS modules, even if they don't produce valid JSON output themselves. This can be achieved by using the `-g` flag for GRASS GIS modules where the result is printed as key - value pairs.

Related to https://github.com/mundialis/actinia_core/pull/239#pullrequestreview-740440275

Example process chain:
```
{
    "list": [
        {
            "module": "g.version",
            "id": "g_version",
            "flags": "rge",
            "inputs": [],
            "stdout": { "id": "output1", "format": "json", "delimiter": "=" }
        },
        {
            "module": "g.region",
            "id": "g_region",
            "flags": "g",
            "inputs": [
              {
                "param": "raster",
                "value": "elevation@PERMANENT"
              }
          ],
          "stdout": { "id": "output2", "format": "json", "delimiter": "=" }
        },
        {
            "module": "r.univar",
            "id": "r_uinvar",
            "flags": "g",
            "inputs": [
                {
                    "param": "map",
                    "value": "elevation"
                },
                {
                    "param": "percentile",
                    "value": "98"
                }
            ],
            "stdout": { "id": "output3", "format": "json", "delimiter": "=" }
        }
    ],
    "version": "1"
}
```
Response:
```
  "process_results": {
    "output1": {
      "build_date": "2021-08-19",
      "build_off_t_size": "8",
      "build_platform": "x86_64-pc-linux-musl",
      "date": "2021",
      "gdal": "3.1.4",
      "geos": "3.8.1",
      "libgis_date": "2021-08-19T19:38:33+00:00",
      "libgis_revision": "2021-08-19T19:38:33+00:00",
      "proj": "7.0.1",
      "revision": "5e2fd30",
      "sqlite": "3.32.1",
      "version": "8.0.dev"
    },
    "output2": {
      "cells": "2025000",
      "cols": "1500",
      "e": "645000",
      "ewres": "10",
      "n": "228500",
      "nsres": "10",
      "projection": "99",
      "rows": "1350",
      "s": "215000",
      "w": "630000",
      "zone": "0"
    },
    "output3": {
      "cells": "2025000",
      "coeff_var": "18.4056555243368",
      "max": "156.329864501953",
      "mean": "110.375440275606",
      "mean_of_abs": "110.375440275606",
      "min": "55.5787925720215",
      "n": "2025000",
      "null_cells": "0",
      "range": "100.751071929932",
      "stddev": "20.3153233205981",
      "sum": "223510266.558102",
      "variance": "412.712361620436"
    }
  },
```

If errors appear during parsing, the response is simply passed over:
```
            "module": "r.univar",
            "flags": "t",
```
```
    },
    "output3": "non_null_cells|null_cells|min|max|range|mean|mean_of_abs|stddev|variance|coeff_var|sum|sum_abs\n2025000|0|55.5787925720215|156.329864501953|100.751071929932|110.375440275606|110.375440275606|20.3153233205981|412.712361620436|18.4056555243368|223510266.558102|223510266.558102\n"
  },
```