### PR TITLE
Add band_names property to STRDSInfoModel

### DIFF
--- a/src/actinia_core/models/openapi/strds_management.py
+++ b/src/actinia_core/models/openapi/strds_management.py
@@ -43,6 +43,7 @@ class STRDSInfoModel(Schema):
     type = 'object'
     properties = {
         "aggregation_type": {'type': 'string'},
+        "band_names": {'type': 'string'},
         "band_reference": {'type': 'string'},
         "bottom": {'type': 'string'},
         "creation_time": {'type': 'string'},
@@ -76,6 +77,7 @@ class STRDSInfoModel(Schema):
     }
     example = {
         "aggregation_type": "None",
+        "band_names": "None",
         "band_reference": "None",
         "bottom": "0.0",
         "creation_time": "2016-08-11 16:44:29.756411",
@@ -161,6 +163,7 @@ class STRDSInfoResponseModel(ProcessingResponseModel):
         ],
         "process_results": {
             "aggregation_type": "None",
+            "band_names": "None",
             "band_reference": "None",
             "bottom": "0.0",
             "creation_time": "2017-12-29 15:58:40.020820",


### PR DESCRIPTION
I have tested the actinia with recent grass gis changes (band names) and I got an error, when requesting t.info from actinia: 

Actinia request for ECAD example dataset: 
`/api/v1/locations/ECAD/mapsets/PERMANENT/strds/precipitation_1950_2013_yearly_mm`

Error: 

```exception: {
message: "The model "STRDSInfoModel" does not have an attribute "band_names"",
traceback: [
" File "/usr/lib/python3.8/site-packages/actinia_core/rest/ephemeral_processing.py", line 1747, in run self._execute() ",
" File "/usr/lib/python3.8/site-packages/actinia_core/rest/strds_management.py", line 410, in _execute self.module_results = STRDSInfoModel(**strds) ",
" File "/usr/lib/python3.8/site-packages/flask_restful_swagger_2/__init__.py", line 336, in __init__ raise ValueError( "
],
type: "<class 'ValueError'>"
},
```

Thus, I have added the property `band_names` to the STRDSInfoModel schema. Do you have a sample dataset with band names available to check the correct behavior?  

With the changes the above request works fine with "None" as band_names value.

Best
Jonas