### PR TITLE
List all available mapsets (issue 162)

### DIFF
--- a/src/actinia_core/models/response_models.py
+++ b/src/actinia_core/models/response_models.py
@@ -197,11 +197,13 @@ class MapsetListResponseModel(Schema):
         'available_mapsets': {
             'type': 'array',
             'items': {'type': 'string'},
-            'description': 'The names of all available mapsets with corresponding locations'
+            'description': ('The names of all available mapsets with'
+                            ' corresponding locations in the global database')
         }
     }
     required = ["status", "available_mapsets"]
-    example = {"status": "success", "available_mapsets": ["nc_spm_08/PERMANENT", "latlong_wgs84/PERMANENT"]}
+    example = {"status": "success", "available_mapsets":
+               ["nc_spm_08/PERMANENT", "latlong_wgs84/PERMANENT"]}
 
 
 class LockedMapsetListResponseModel(Schema):

--- a/src/actinia_core/models/response_models.py
+++ b/src/actinia_core/models/response_models.py
@@ -184,6 +184,26 @@ class SimpleResponseModel(Schema):
     required = ["status", "message"]
 
 
+class MapsetListResponseModel(Schema):
+    """Response schema that is used to list all mapsets available to the user.
+
+    """
+    type = 'object'
+    properties = {
+        'status': {
+            'type': 'string',
+            'description': 'The status of the request'
+        },
+        'available_mapsets': {
+            'type': 'array',
+            'items': {'type': 'string'},
+            'description': 'The names of all available mapsets with corresponding locations'
+        }
+    }
+    required = ["status", "available_mapsets"]
+    example = {"status": "success", "available_mapsets": ["nc_spm_08/PERMANENT", "latlong_wgs84/PERMANENT"]}
+
+
 class LockedMapsetListResponseModel(Schema):
     """Response schema that is used to list all locked mapsets.
 

--- a/src/actinia_core/rest/mapsets.py
+++ b/src/actinia_core/rest/mapsets.py
@@ -143,7 +143,7 @@ class AllMapsetsListingResourceAdmin(ResourceBase):
                     return make_response(jsonify(SimpleResponseModel(
                         status="error",
                         message=(f"Unable to list mapsets for user {user}: You are not authorized for this request. "
-                                 "Minimum required user role: superadmin %s")
+                                 "Minimum required user role: superadmin")
                                 )), 401)
             else:
                 user = self.user.get_id()

--- a/src/actinia_core/rest/mapsets.py
+++ b/src/actinia_core/rest/mapsets.py
@@ -64,21 +64,21 @@ class AllMapsetsListingResourceAdmin(ResourceBase):
                 'in': 'path',
                 'name': 'mapsets',
                 'type': 'string',
-                'description': "List all mapsets available to the authenticated user."
+                'description': "List all mapsets in the global database available to the authenticated user."
             },
             {
                 'in': 'path',
                 'name': 'status',
                 'type': 'string',
-                'description': ("If set to 'locked', list all locked mapsets across"
-                                " all locations. Minimum required user role: admin.")
+                'description': ("If set to 'locked', list all locked mapsets across "
+                                "all locations. Minimum required user role: admin.")
             },
             {
                 'in': 'path',
                 'name': 'user',
                 'type': 'string',
-                'description': ("List all mapsets available to the specified user. "
-                                "Minimum required user role: admin")
+                'description': ("List all mapsets in the global database available "
+                                "to the specified user. Minimum required user role: admin")
             }],
         'responses': {
             '200': {
@@ -98,8 +98,8 @@ class AllMapsetsListingResourceAdmin(ResourceBase):
                 if self.user.has_superadmin_role() is False:
                     return make_response(jsonify(SimpleResponseModel(
                         status="error",
-                        message=("Unable to list locked mapsets You are not authorized for this request. "
-                                 "Minimum required user role: superadmin %s")
+                        message=("Unable to list locked mapsets You are not authorized"
+                                 "for this request. Minimum required user role: superadmin")
                                 )), 401)
                 redis_interface = RedisLockingInterface()
                 kwargs = dict()
@@ -142,7 +142,8 @@ class AllMapsetsListingResourceAdmin(ResourceBase):
                 if self.user.has_superadmin_role() is False:
                     return make_response(jsonify(SimpleResponseModel(
                         status="error",
-                        message=(f"Unable to list mapsets for user {user}: You are not authorized for this request. "
+                        message=(f"Unable to list mapsets for user {user}: You are not"
+                                 " authorized for this request. "
                                  "Minimum required user role: superadmin")
                                 )), 401)
             else:

--- a/src/actinia_core/rest/mapsets.py
+++ b/src/actinia_core/rest/mapsets.py
@@ -101,7 +101,7 @@ class AllMapsetsListingResourceAdmin(ResourceBase):
                     return make_response(jsonify(SimpleResponseModel(
                         status="error",
                         message=("Unable to list locked mapsets You are not authorized"
-                                 "for this request. "
+                                 " for this request. "
                                  "Minimum required user role: superadmin")
                                 )), 401)
                 redis_interface = RedisLockingInterface()
@@ -139,10 +139,10 @@ class AllMapsetsListingResourceAdmin(ResourceBase):
                     and global_config.REDIS_SERVER_PW is not None):
                 kwargs["password"] = global_config.REDIS_SERVER_PW
             redis_interface.connect(**kwargs)
-            redis_connection = redis_interface.redis_server
             if "user" in request.args:
                 user = request.args["user"]
                 if self.user.has_superadmin_role() is False:
+                    redis_interface.disconnect()
                     return make_response(jsonify(SimpleResponseModel(
                         status="error",
                         message=(f"Unable to list mapsets for user {user}: You are not"
@@ -153,6 +153,7 @@ class AllMapsetsListingResourceAdmin(ResourceBase):
                 user = self.user.get_id()
             locs_mapsets = (redis_interface.get_credentials(user)["permissions"]
                             ["accessible_datasets"])
+            redis_interface.disconnect()
             mapsets = []
             for location in locs_mapsets:
                 for mapset in locs_mapsets[location]:

--- a/src/actinia_core/rest/mapsets.py
+++ b/src/actinia_core/rest/mapsets.py
@@ -61,6 +61,7 @@ class AllMapsetsListingResourceAdmin(ResourceBase):
         'description': 'List available or locked mapsets.',
         'parameters': [
             {
+                'in': 'path',
                 'name': 'mapsets',
                 'type': 'string',
                 'description': "List all mapsets available to the authenticated user."

--- a/src/actinia_core/rest/mapsets.py
+++ b/src/actinia_core/rest/mapsets.py
@@ -64,7 +64,8 @@ class AllMapsetsListingResourceAdmin(ResourceBase):
                 'in': 'path',
                 'name': 'mapsets',
                 'type': 'string',
-                'description': "List all mapsets in the global database available to the authenticated user."
+                'description': "List all mapsets in the global database available "
+                               "to the authenticated user."
             },
             {
                 'in': 'path',
@@ -78,7 +79,8 @@ class AllMapsetsListingResourceAdmin(ResourceBase):
                 'name': 'user',
                 'type': 'string',
                 'description': ("List all mapsets in the global database available "
-                                "to the specified user. Minimum required user role: admin")
+                                "to the specified user. "
+                                "Minimum required user role: admin")
             }],
         'responses': {
             '200': {
@@ -99,7 +101,8 @@ class AllMapsetsListingResourceAdmin(ResourceBase):
                     return make_response(jsonify(SimpleResponseModel(
                         status="error",
                         message=("Unable to list locked mapsets You are not authorized"
-                                 "for this request. Minimum required user role: superadmin")
+                                 "for this request. "
+                                 "Minimum required user role: superadmin")
                                 )), 401)
                 redis_interface = RedisLockingInterface()
                 kwargs = dict()

--- a/src/actinia_core/rest/mapsets.py
+++ b/src/actinia_core/rest/mapsets.py
@@ -25,7 +25,7 @@
 Mapset resources for information across all locations
 
 * List all mapset locks
-* TODO: List all mapsets in all locations
+* List all mapsets in all locations available to a user
 """
 
 from flask import jsonify, make_response
@@ -58,19 +58,30 @@ class AllMapsetsListingResourceAdmin(ResourceBase):
 
     @swagger.doc({
         'tags': ['Mapsets'],
-        'description': 'Get all locked mapsets. '
-                       'Minimum required user role: admin.',
+        'description': 'List available or locked mapsets.',
         'parameters': [
+            {
+                'name': 'mapsets',
+                'type': 'string',
+                'description': "List all mapsets available to the authenticated user."
+            },
             {
                 'in': 'path',
                 'name': 'status',
                 'type': 'string',
                 'description': ("If set to 'locked', list all locked mapsets across"
-                                " all locations.")
+                                " all locations. Minimum required user role: admin.")
+            },
+            {
+                'in': 'path',
+                'name': 'user',
+                'type': 'string',
+                'description': ("List all mapsets available to the specified user. "
+                                "Minimum required user role: admin")
             }],
         'responses': {
             '200': {
-                'description': 'Get a list of (locked) mapsets ',
+                'description': 'Returns a list of available (or locked) mapsets ',
                 'schema': LockedMapsetListResponseModel
             },
             '500': {

--- a/tests/test_mapsets.py
+++ b/tests/test_mapsets.py
@@ -80,9 +80,9 @@ class MapsetsTestCase(ActiniaResourceTestCaseBase):
         for mapset in self.test_mapsets:
             self.create_new_mapset(mapset)
             rvpost = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/lock' % mapset,
-                                      headers=self.admin_auth_header)
+                                      headers=self.root_auth_header)
         rv = self.server.get(URL_PREFIX + '/mapsets?status=locked',
-                             headers=self.admin_auth_header)
+                             headers=self.root_auth_header)
         self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
         self.assertEqual(rv.mimetype, "application/json", "Wrong mimetype %s" % rv.mimetype)
         rvdata = json_load(rv.data)

--- a/tests/test_mapsets.py
+++ b/tests/test_mapsets.py
@@ -104,7 +104,8 @@ class MapsetsTestCase(ActiniaResourceTestCaseBase):
         self.assertEqual(rv.status_code, 401, "Status code is not 401: %s" % rv.status_code)
 
     def test_user_own_mapsets(self):
-        # Test if user can list available mapsets
+        """Test if user can list available mapsets
+        """
         rv = self.server.get(URL_PREFIX + '/mapsets', headers=self.test_user_auth_header)
         self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
         rvdata = json_load(rv.data)
@@ -112,7 +113,8 @@ class MapsetsTestCase(ActiniaResourceTestCaseBase):
         self.assertEqual(mapsets, self.ref_mapsets, "Mapset list is not equal to reference mapset list")
 
     def test_superadmin_user_mapsets(self):
-        # Test if superadmin can list available mapsets from test_user
+        """Test if superadmin can list available mapsets from test_user
+        """
         rv = self.server.get(URL_PREFIX + f'/mapsets?user={self.test_user}', headers=self.root_auth_header)
         self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
         rvdata = json_load(rv.data)

--- a/tests/test_mapsets.py
+++ b/tests/test_mapsets.py
@@ -27,7 +27,6 @@ Tests: Mapset test case
 from flask.json import loads as json_load
 import uuid
 import unittest
-from actinia_core.core.common.user import ActiniaUser
 try:
     from .test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
 except:
@@ -43,18 +42,7 @@ class MapsetsTestCase(ActiniaResourceTestCaseBase):
 
     test_mapsets = [str(uuid.uuid4()), str(uuid.uuid4())]
 
-    test_userid = f"test_user_{uuid.uuid4()}"
-
-    def setUp(self):
-        # create and lock mapsets
-        for mapset in self.test_mapsets:
-            self.create_new_mapset(mapset)
-            rvpost = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/lock' % mapset,
-                                      headers=self.admin_auth_header)
-        # create new user
-        user = ActiniaUser(self.test_userid)
-
-    def tearDownClass(self):
+    def tearDown(self):
         # unlock and delete the test mapsets
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets',
                              headers=self.user_auth_header)
@@ -70,19 +58,13 @@ class MapsetsTestCase(ActiniaResourceTestCaseBase):
                     URL_PREFIX + '/locations/nc_spm_08/mapsets/%s' % mapset,
                     headers=self.admin_auth_header)
                 print(rvdel.data.decode())
-        # delete the new user
-        ActiniaUser.delete(self.test_userid)
-
-
-    # def
-    #         cls.user_id, cls.user_group, cls.user_auth_header = cls.create_user(
-    #             name="user", role="user", process_num_limit=3, process_time_limit=4,
-    #             accessible_datasets=accessible_datasets)
 
     def test_two_locked_mapsets(self):
-        import pdb; pdb.set_trace()
         # Test correct behaviour if two mapsets are locked
-
+        for mapset in self.test_mapsets:
+            self.create_new_mapset(mapset)
+            rvpost = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/lock' % mapset,
+                                      headers=self.admin_auth_header)
         rv = self.server.get(URL_PREFIX + '/mapsets?status=locked',
                              headers=self.admin_auth_header)
         self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)

--- a/tests/test_mapsets.py
+++ b/tests/test_mapsets.py
@@ -41,6 +41,22 @@ __maintainer__ = "mundialis"
 class MapsetsTestCase(ActiniaResourceTestCaseBase):
 
     test_mapsets = [str(uuid.uuid4()), str(uuid.uuid4())]
+    test_user = f"test_user_{str(uuid.uuid4())}"
+    accessible_datasets = {"nc_spm_08": ["PERMANENT"],
+                           "latlong_wgs84": ["PERMANENT"]}
+    ref_mapsets = []
+    for location in accessible_datasets:
+        for mapset in accessible_datasets[location]:
+            ref_mapsets.append(f"{location}/{mapset}")
+
+    @classmethod
+    def setUpClass(cls):
+        super(ActiniaResourceTestCaseBase, cls).setUpClass()
+
+        # Create test_user
+        cls.test_user_id, cls.test_user_group, cls.test_user_auth_header = cls.create_user(
+            name=cls.test_user, role="user",
+            accessible_datasets=cls.accessible_datasets)
 
     def tearDown(self):
         # unlock and delete the test mapsets
@@ -85,6 +101,27 @@ class MapsetsTestCase(ActiniaResourceTestCaseBase):
         # Test correct behaviour if user role is not admin
         rv = self.server.get(URL_PREFIX + '/mapsets?status=locked',
                              headers=self.user_auth_header)
+        self.assertEqual(rv.status_code, 401, "Status code is not 401: %s" % rv.status_code)
+
+    def test_user_own_mapsets(self):
+        # Test if user can list available mapsets
+        rv = self.server.get(URL_PREFIX + '/mapsets', headers=self.test_user_auth_header)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        rvdata = json_load(rv.data)
+        mapsets = rvdata["available_mapsets"]
+        self.assertEqual(mapsets, self.ref_mapsets, "Mapset list is not equal to reference mapset list")
+
+    def test_superadmin_user_mapsets(self):
+        # Test if superadmin can list available mapsets from test_user
+        rv = self.server.get(URL_PREFIX + f'/mapsets?user={self.test_user}', headers=self.root_auth_header)
+        self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
+        rvdata = json_load(rv.data)
+        mapsets = rvdata["available_mapsets"]
+        self.assertEqual(mapsets, self.ref_mapsets, "Mapset list is not equal to reference mapset list")
+
+    def test_user_user_mapsets(self):
+        # Test if test_user can list available mapsets from user
+        rv = self.server.get(URL_PREFIX + f'/mapsets?user={self.test_user}', headers=self.user_auth_header)
         self.assertEqual(rv.status_code, 401, "Status code is not 401: %s" % rv.status_code)
 
 

--- a/tests/test_mapsets.py
+++ b/tests/test_mapsets.py
@@ -27,6 +27,7 @@ Tests: Mapset test case
 from flask.json import loads as json_load
 import uuid
 import unittest
+from actinia_core.core.common.user import ActiniaUser
 try:
     from .test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
 except:
@@ -42,7 +43,18 @@ class MapsetsTestCase(ActiniaResourceTestCaseBase):
 
     test_mapsets = [str(uuid.uuid4()), str(uuid.uuid4())]
 
-    def tearDown(self):
+    test_userid = f"test_user_{uuid.uuid4()}"
+
+    def setUp(self):
+        # create and lock mapsets
+        for mapset in self.test_mapsets:
+            self.create_new_mapset(mapset)
+            rvpost = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/lock' % mapset,
+                                      headers=self.admin_auth_header)
+        # create new user
+        user = ActiniaUser(self.test_userid)
+
+    def tearDownClass(self):
         # unlock and delete the test mapsets
         rv = self.server.get(URL_PREFIX + '/locations/nc_spm_08/mapsets',
                              headers=self.user_auth_header)
@@ -58,13 +70,19 @@ class MapsetsTestCase(ActiniaResourceTestCaseBase):
                     URL_PREFIX + '/locations/nc_spm_08/mapsets/%s' % mapset,
                     headers=self.admin_auth_header)
                 print(rvdel.data.decode())
+        # delete the new user
+        ActiniaUser.delete(self.test_userid)
+
+
+    # def
+    #         cls.user_id, cls.user_group, cls.user_auth_header = cls.create_user(
+    #             name="user", role="user", process_num_limit=3, process_time_limit=4,
+    #             accessible_datasets=accessible_datasets)
 
     def test_two_locked_mapsets(self):
+        import pdb; pdb.set_trace()
         # Test correct behaviour if two mapsets are locked
-        for mapset in self.test_mapsets:
-            self.create_new_mapset(mapset)
-            rvpost = self.server.post(URL_PREFIX + '/locations/nc_spm_08/mapsets/%s/lock' % mapset,
-                                      headers=self.admin_auth_header)
+
         rv = self.server.get(URL_PREFIX + '/mapsets?status=locked',
                              headers=self.admin_auth_header)
         self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)


### PR DESCRIPTION
The `/mapsets` endpoint now gives an overview of all mapsets in the **global** database the authenticated user has access to. A superadmin can check individual user's available mapsets by using `mapsets?user=<user_id>`.
See #162 
developed with @juleshaas 