### PR TITLE
Fix: create user endpoint

### DIFF
--- a/src/actinia_core/rest/resource_management.py
+++ b/src/actinia_core/rest/resource_management.py
@@ -107,7 +107,7 @@ class ResourceManagerBase(Resource):
         new_user = ActiniaUser(user_id=user_id)
 
         # Check if the user exists
-        if new_user.exists() is False:
+        if new_user.exists() != 1:
             return make_response(jsonify(SimpleResponseModel(
                 status="error",
                 message="The user <%s> does not exist" % user_id)), 400)

--- a/src/actinia_core/rest/user_management.py
+++ b/src/actinia_core/rest/user_management.py
@@ -138,7 +138,7 @@ class UserManagementResource(LoginBase):
         """
         user = ActiniaUser(user_id)
 
-        if user.exists() is False:
+        if user.exists() != 1:
             return make_response(jsonify(SimpleResponseModel(
                 status="error",
                 message="User <%s> does not exist" % user_id
@@ -170,14 +170,14 @@ class UserManagementResource(LoginBase):
                 'name': 'password',
                 'description': 'The password of the new user',
                 'required': True,
-                'in': 'path',
+                'in': 'query',
                 'type': 'string'
             },
             {
                 'name': 'group',
                 'description': 'The group of the new user',
                 'required': True,
-                'in': 'path',
+                'in': 'query',
                 'type': 'string'
             }
         ],
@@ -212,15 +212,13 @@ class UserManagementResource(LoginBase):
                                      type=str, help='The password of the new user')
         password_parser.add_argument('group', required=True,
                                      type=str, help='The group of the new user')
-
         args = password_parser.parse_args()
         password = args["password"]
         group = args["group"]
 
         user = ActiniaUser.create_user(user_id, group, password, "user", {})
-
         if user is not None:
-            if user.exists() is True:
+            if user.exists():
                 return make_response(jsonify(SimpleResponseModel(
                     status="success",
                     message="User %s created" % user_id
@@ -271,7 +269,7 @@ class UserManagementResource(LoginBase):
         """
         user = ActiniaUser(user_id)
 
-        if user.exists() is False:
+        if user.exists() != 1:
             return make_response(jsonify(SimpleResponseModel(
                 status="error",
                 message="Unable to delete user %s. User does not exist." % user_id


### PR DESCRIPTION
When creating a new user via the endpoint `/users/<user_id>?password=<password>&group=<group>`, the `user.exists()` method is used, which returns `0` or `1`, but `True` or `False` are expected, so the response is an error even though user creation was successful. This is fixed in this PR.  
A user is created via the url `/users/<user_id>?password=<password>&group=<group>`. The last two parameters are thus in the `query` part of the url and not in the `path`. This is adapted in the `swagger.doc`.