### PR TITLE
Add stac plugin to alpine config

### DIFF
--- a/docker/actinia-core-alpine/actinia.cfg
+++ b/docker/actinia-core-alpine/actinia.cfg
@@ -8,7 +8,7 @@ grass_gis_start_script = /usr/local/bin/grass
 grass_addon_path = /root/.grass7/addons/
 
 [API]
-plugins = ["actinia_statistic_plugin", "actinia_satellite_plugin", "actinia_metadata_plugin", "actinia_module_plugin"]
+plugins = ["actinia_statistic_plugin", "actinia_satellite_plugin", "actinia_metadata_plugin", "actinia_module_plugin", "actinia_stac_plugin"]
 force_https_urls = True
 
 [REDIS]


### PR DESCRIPTION
As the config is usually overwritten for deployments, this was not catched earlier, but is of course helpful because the plugin is contained in the Dockerfile. With this PR, the STAC endpoints are available on startup without the need to modify the config.