### PR TITLE
Add api_version to version endpoint

### DIFF
--- a/docker/actinia-core-alpine/Dockerfile
+++ b/docker/actinia-core-alpine/Dockerfile
@@ -79,8 +79,8 @@ RUN curl https://api.github.com/repos/mundialis/actinia-module-plugin/releases/5
 RUN curl https://api.github.com/repos/mundialis/actinia-stac-plugin/releases/54012264 > resp.json && \
     name=`cat resp.json | jq '.assets[0].name' | tr -d '"'` && \
     cat resp.json | jq '.assets[0].browser_download_url' | xargs curl -L --output /build/$name && rm resp.json
-# Get actinia-api (54010688 = 2.0.0)
-RUN curl https://api.github.com/repos/mundialis/actinia-api/releases/54010688 > resp.json && \
+# Get actinia-api (54480911 = 2.0.1)
+RUN curl https://api.github.com/repos/mundialis/actinia-api/releases/54480911 > resp.json && \
     name=`cat resp.json | jq '.assets[0].name' | tr -d '"'` && \
     cat resp.json | jq '.assets[0].browser_download_url' | xargs curl -L --output /build/$name && rm resp.json
 

--- a/src/actinia_core/version.py
+++ b/src/actinia_core/version.py
@@ -49,10 +49,12 @@ from . import __version__
 G_VERSION = {}
 PLUGIN_VERSIONS = {}
 PYTHON_VERSION = ""
+API_VERSION = ""
 
 
 def init_versions():
     global PYTHON_VERSION
+    global API_VERSION
 
     g_version = subprocess.run(
         ['grass', '--tmp-location', 'epsg:4326', '--exec',
@@ -65,6 +67,10 @@ def init_versions():
     for i in global_config.PLUGINS:
         module = importlib.import_module(i)
         PLUGIN_VERSIONS[i] = module.__version__
+
+    log.debug('Detecting API versions')
+    module = importlib.import_module("actinia_api")
+    API_VERSION = module.__version__
 
     PYTHON_VERSION = sys.version.replace('\n', '- ')
 
@@ -131,6 +137,7 @@ def version():
     info['plugins'] = ",".join(global_config.PLUGINS)
     info['grass_version'] = G_VERSION
     info['plugin_versions'] = PLUGIN_VERSIONS
+    info['api_version'] = API_VERSION
     info['python_version'] = PYTHON_VERSION
     info['running_since'] = find_running_since_info()
 

--- a/src/actinia_core/version.py
+++ b/src/actinia_core/version.py
@@ -85,7 +85,7 @@ def valid_additional_version_info_key(cand):
     valid_reg_ex = '^[a-z_]{' + str(minlength) + ',' + str(maxlength) + '}$'
     reserved_keys = [
         'grass_version', 'plugin_versions', 'plugins', 'python_version',
-        'version'
+        'version', 'api_version'
     ]
     return cand and cand not in reserved_keys and re.match(valid_reg_ex, cand)
 


### PR DESCRIPTION
This PR also adds the `api_version` to the `/version` endpoint:

```
{
    "api_version": "2.0.1",
    "grass_version": {
        "build_date": "2021-11-22",
        "build_off_t_size": "8",
        "build_platform": "x86_64-pc-linux-musl",
        "date": "2021",
        "gdal": "3.1.4",
        "geos": "3.8.1",
        "libgis_date": "2021-11-22T20:21:43+00:00",
        "libgis_revision": "2021-11-22T20:21:43+00:00",
        "proj": "7.0.1",
        "revision": "abb1214",
        "sqlite": "3.32.1",
        "version": "7.8.7dev"
    },
    "plugin_versions": {
        "actinia_metadata_plugin": "1.0.2",
        "actinia_module_plugin": "2.2.3",
        "actinia_satellite_plugin": "0.0.4",
        "actinia_stac_plugin": "0.0.1",
        "actinia_statistic_plugin": "0.0.4"
        },
    "plugins": "actinia_statistic_plugin,actinia_satellite_plugin,actinia_metadata_plugin,actinia_module_plugin,actinia_stac_plugin",
    "python_version": "3.8.5 (default, Jul 20 2020, 23:11:29) - [GCC 9.3.0]",
    "running_since": "n/a",
    "version": "2.0.1.post0.dev2+g1ef779c.dirty"
}
```

Depends on https://github.com/mundialis/actinia-api/pull/1 (updated in Dockerfile)