### PR TITLE
New splitup in unit and integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
 
-  alpine-unit-tests:
+  alpine-unittests:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -18,7 +18,7 @@ jobs:
       #   path: "."
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Replace run test command
+    - name: Replace run only unittest command
       run: |
         sed -i "s+# RUN make test+RUN make unittest+g" docker/actinia-core-tests/Dockerfile
     - name: Unittests of actinia
@@ -41,7 +41,7 @@ jobs:
       #   path: "."
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Replace run test command
+    - name: Replace run integration test command
       run: |
         sed -i "s+# RUN make test+RUN make integrationtest+g" docker/actinia-core-tests/Dockerfile
     - name: Integration tests of actinia

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
 
-  alpine-tests:
+  alpine-unit-tests:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -18,7 +18,33 @@ jobs:
       #   path: "."
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Test actinia
+    - name: Replace run test command
+      run: |
+        sed -i "s+# RUN make test+RUN make unittest+g" docker/actinia-core-tests/Dockerfile
+    - name: Unittests of actinia
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        tags: actinia-core-tests:alpine
+        context: .
+        file: docker/actinia-core-tests/Dockerfile
+        no-cache: true
+        # pull: true
+
+  alpine-integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      # with:
+      #   path: "."
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Replace run test command
+      run: |
+        sed -i "s+# RUN make test+RUN make integrationtest+g" docker/actinia-core-tests/Dockerfile
+    - name: Integration tests of actinia
       id: docker_build
       uses: docker/build-push-action@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ devtest:
 	./tests_with_redis.sh dev
 
 integrationtest:
-	./tests_with_redis.sh notunittest
+	./tests_with_redis.sh integrationtest

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,12 @@ dist:
 
 test:
 	./tests_with_redis.sh
+
+unittest:
+	python3 setup.py test --addopts "-m unittest"
+
+devtest:
+	./tests_with_redis.sh dev
+
+integrationtest:
+	./tests_with_redis.sh notunittest

--- a/docker/actinia-core-alpine/actinia.cfg
+++ b/docker/actinia-core-alpine/actinia.cfg
@@ -8,7 +8,7 @@ grass_gis_start_script = /usr/local/bin/grass
 grass_addon_path = /root/.grass7/addons/
 
 [API]
-plugins = ["actinia_statistic_plugin", "actinia_satellite_plugin", "actinia_metadata_plugin", "actinia_module_plugin"]
+plugins = ["actinia_statistic_plugin", "actinia_satellite_plugin", "actinia_metadata_plugin", "actinia_module_plugin", "actinia_stac_plugin"]
 force_https_urls = True
 
 [REDIS]

--- a/docker/actinia-core-tests/Dockerfile
+++ b/docker/actinia-core-tests/Dockerfile
@@ -45,4 +45,4 @@ RUN chmod a+x tests_with_redis.sh
 
 RUN make install
 
-RUN make test
+# RUN make test

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,9 @@ norecursedirs =
     dist
     build
     .tox
+markers =
+    dev: test current in development
+    unittest: completely independent test
 
 [aliases]
 release = sdist bdist_wheel upload

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,6 +16,8 @@ docker build -f docker/actinia-core-tests/Dockerfile -t actinia-test .
 ```
 3. To run only a few tests you can mark the tests for development with
 `@pytest.mark.dev` and add `import pytest` to the file.
+(For best practice examples on the use of pytest-decorators, see `unittests/test_version.py`)
+
 
 4. Start the docker container and mount your `tests` folder:
 
@@ -34,7 +36,7 @@ docker run -it actinia-test:latest -i
 make test
 
 # execute only integration tests (not unittests)
-make notunittest
+make integrationtest
 
 # execute only unit tests
 make unittest
@@ -45,8 +47,6 @@ make devtest
 # If you added a debugger to your test it will stop there.
 # After making changes to the test, you need to close and restart the docker container (docker run ...) before testing again.
 ```
-
-When you are done, add your new test(s) to `actinia_core/tests`. You can run the entire testsuite including your new tests by rebuilding the docker image and running the container without mounting (see 4.)
 
 
 ## Problems

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,6 +33,9 @@ docker run -it actinia-test:latest -i
 # execute all tests
 make test
 
+# execute only integration tests (not unittests)
+make notunittest
+
 # execute only unit tests
 make unittest
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,20 +14,15 @@ When writing new tests it is useful to run selected tests locally and isolated. 
 ```
 docker build -f docker/actinia-core-tests/Dockerfile -t actinia-test .
 ```
-3. Create a local `tmp_tests` folder and fill it with the files:
+3. To run only a few tests you can mark the tests for development with
+`@pytest.mark.dev` and add `import pytest` to the file.
 
-- `tests/__init__.py`
-- `tests/conftest.py`
-- `tests/test_resource_base.py`
-- your_new_test(s).py
-
-
-4. Start the docker container and mount your local `tmp_tests` folder:
+4. Start the docker container and mount your `tests` folder:
 
 ```
-docker run -it -v /path/to/tmp_tests:/src/actinia_core/tests actinia-test:latest -i
+docker run -it -v /path/to/tests:/src/actinia_core/tests actinia-test:latest -i
 
-# If you want to run all tests from actinia_core/tests instead of selected ones you can use the following command:
+# If you are not developing the tests you can run tests using the following command:
 docker run -it actinia-test:latest -i
 
 ```
@@ -35,7 +30,14 @@ docker run -it actinia-test:latest -i
 5. To execute the test(s) run:
 
 ```
+# execute all tests
 make test
+
+# execute only unit tests
+make unittest
+
+# execute tests marked with '@pytest.mark.dev'
+make devtest
 
 # If you added a debugger to your test it will stop there.
 # After making changes to the test, you need to close and restart the docker container (docker run ...) before testing again.

--- a/tests/unittests/test_version.py
+++ b/tests/unittests/test_version.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#######
+# actinia-core - an open source REST API for scalable, distributed, high
+# performance processing of geographical data that uses GRASS GIS for
+# computational tasks. For details, see https://actinia.mundialis.de/
+#
+# Copyright (c) 2016-2018 Sören Gebbert and mundialis GmbH & Co. KG
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#######
+
+"""
+Tests: Version unittest case
+"""
+import os
+import pytest
+import re
+import unittest
+
+from actinia_core.version import (
+    find_running_since_info,
+    find_additional_version_info,
+    parse_additional_version_info,
+    valid_additional_version_info_key
+)
+
+__license__ = "GPLv3"
+__author__ = "Anika Weinmann"
+__copyright__ = "Copyright 2021, mundialis GmbH & Co. KG"
+__maintainer__ = "mundialis"
+
+
+add_versions = {
+    'test_key_a': 'test_val_a',
+    'test_key_b': 'test_val_b',
+    'test_key_c': 'test_val_c'
+}
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize("key,status", [
+    ('test_key_a', True),
+    ('number1', False),
+    ('a!', False),
+    ('a-', False),
+    ('', False),
+    ('a' * 21, False)
+])
+def test_valid_additional_version_info_key(key, status):
+    test = valid_additional_version_info_key(key)
+    if status is True:
+        assert test, f"Key <{key}> is wrong"
+    else:
+        assert not test, f"Key <{key}> is not wrong"
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize("use_env,val", [
+    (False, 'n/a'),
+    (True, 'test')
+])
+def test_find_running_since_info(use_env, val):
+
+    if use_env is True:
+        os.environ['ACTINIA_RUNNING_SINCE'] = val
+    test = find_running_since_info()
+    assert test == val, f"Running since info is not '{val}'"
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize("env_value,expected", [
+    ('', {}),
+    ([f"{key}:{val}" for key, val in add_versions.items()][0],
+     {list(add_versions.keys())[0]:add_versions[list(add_versions.keys())[0]]}),
+    ("|".join([f"{key}:{val}" for key, val in add_versions.items()]), add_versions)
+])
+def test_parse_additional_version_info(env_value, expected):
+
+    test = parse_additional_version_info(env_value)
+    assert test == expected, "Find additional version is not right"
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize("env_value,expected", [
+    ('', {}),
+    ([f"{key}:{val}" for key, val in add_versions.items()][0],
+     {list(add_versions.keys())[0]:add_versions[list(add_versions.keys())[0]]}),
+    ("|".join([f"{key}:{val}" for key, val in add_versions.items()]), add_versions),
+    (f'{"|".join([f"{key}:{val}" for key, val in add_versions.items()])}|'
+     'key_1:test', add_versions)
+])
+def test_find_additional_version_info(env_value, expected):
+
+    if env_value != '':
+        os.environ['ACTINIA_ADDITIONAL_VERSION_INFO'] = env_value
+    else:
+        if 'ACTINIA_ADDITIONAL_VERSION_INFO' in os.environ:
+            del os.environ['ACTINIA_ADDITIONAL_VERSION_INFO']
+    test = find_additional_version_info()
+    assert test == expected, "Additional version is not right"

--- a/tests_with_redis.sh
+++ b/tests_with_redis.sh
@@ -12,4 +12,17 @@ sleep 10
 # run tests
 echo $ACTINIA_CUSTOM_TEST_CFG
 echo $DEFAULT_CONFIG_PATH
-python3 setup.py test
+
+if [ "$1" == "dev" ]
+then
+  echo "Executing only 'dev' tests ..."
+  python3 setup.py test --addopts "-m dev"
+elif [ "$1" == "notunittest" ]
+then
+  python3 setup.py test --addopts "-m 'not unittest'"
+else
+  python3 setup.py test
+fi
+
+# stop redis server
+redis-cli shutdown

--- a/tests_with_redis.sh
+++ b/tests_with_redis.sh
@@ -17,7 +17,7 @@ if [ "$1" == "dev" ]
 then
   echo "Executing only 'dev' tests ..."
   python3 setup.py test --addopts "-m dev"
-elif [ "$1" == "notunittest" ]
+elif [ "$1" == "integrationtest" ]
 then
   python3 setup.py test --addopts "-m 'not unittest'"
 else


### PR DESCRIPTION
The tests are now splitted into unittests marked with `@pytest.mark.unittest` and others (= integration tests).
As unittest example there are added few tests for the version but any other test method can be marked as unittest.
For development of the tests you can add a marker `@pytest.mark.dev` to specific tests and run only the marked tests with `make devtest` see [tests/README.md](https://github.com/mundialis/actinia_core/blob/tests/tests/README.md).

The integration and unittests are both added to the github actions.