### PR TITLE
Enhance dev setup

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -48,6 +48,7 @@
 					"hostPort": 8088
 				  }
 				],
+				"customOptions": "--ip 172.18.0.11",
 				"volumes": [
 					// mount local source code for instant reload
 					// on changes

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -48,3 +48,6 @@ services:
 
 networks:
   actinia-dev:
+    ipam:
+      config:
+        - subnet: 172.18.0.0/16


### PR DESCRIPTION
This PR enhances the local dev setup. It adds a default IP adress to be used for actinia-core.
This is mainly useful for development of the [openeo-grassgis-driver](https://github.com/Open-EO/openeo-grassgis-driver).

Related to https://github.com/Open-EO/openeo-grassgis-driver/pull/132