### PR TITLE
Fix tests

### DIFF
--- a/tests/test_async_process_validation.py
+++ b/tests/test_async_process_validation.py
@@ -29,13 +29,21 @@ import unittest
 from flask.json import dumps as json_dumps
 
 try:
-    from .test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+    from .test_resource_base import (
+        ActiniaResourceTestCaseBase,
+        URL_PREFIX,
+        additional_external_data
+    )
 except ModuleNotFoundError:
-    from test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+    from test_resource_base import (
+        ActiniaResourceTestCaseBase,
+        URL_PREFIX,
+        additional_external_data
+    )
 
 __license__ = "GPLv3"
 __author__ = "Sören Gebbert"
-__copyright__ = "Copyright 2016-2018, Sören Gebbert and mundialis GmbH & Co. KG"
+__copyright__ = "Copyright 2016-2022, Sören Gebbert and mundialis GmbH & Co. KG"
 __maintainer__ = "Sören Gebbert"
 __email__ = "soerengebbert@googlemail.com"
 
@@ -201,8 +209,9 @@ process_chain_ndvi_landsat = {
                                       "landsat_atcor": "dos1"},
                      "param": "map",
                      "value": "ignored"},
-                    {"import_descr": {"source": "https://apps.mundialis.de/actinia_test_datasets/rio.json",
-                                      "type": "vector"},
+                    {"import_descr": {
+                        "source": additional_external_data["rio_json"],
+                        "type": "vector"},
                      "param": "map",
                      "value": "polygon"}]},
 

--- a/tests/test_async_process_validation.py
+++ b/tests/test_async_process_validation.py
@@ -191,6 +191,7 @@ process_chain_ndvi = {
 # Import a Sentinel2A scene and compute the NDVI for a specific polygon
 # https://storage.googleapis.com/graas-geodata/rio.json
 # https://gdh-data-sandbox.ams3.digitaloceanspaces.com/rio.json
+# https://apps.mundialis.de/actinia_test_datasets/rio.json
 process_chain_ndvi_landsat = {
     "list": [
         {"id": "importer_1",
@@ -200,7 +201,7 @@ process_chain_ndvi_landsat = {
                                       "landsat_atcor": "dos1"},
                      "param": "map",
                      "value": "ignored"},
-                    {"import_descr": {"source": "https://storage.googleapis.com/graas-geodata/rio.json",
+                    {"import_descr": {"source": "https://apps.mundialis.de/actinia_test_datasets/rio.json",
                                       "type": "vector"},
                      "param": "map",
                      "value": "polygon"}]},

--- a/tests/test_async_processing_2.py
+++ b/tests/test_async_processing_2.py
@@ -180,7 +180,7 @@ process_chain_ndvi = {
                                       "sentinel_band": "B08"},
                      "param": "map",
                      "value": "B08"},
-                    {"import_descr": {"source": "https://storage.googleapis.com/graas-geodata/brazil_polygon.json",
+                    {"import_descr": {"source": "https://apps.mundialis.de/actinia_test_datasets/brazil_polygon.json",
                                       "type": "vector"},
                      "param": "map",
                      "value": "polygon"}]},
@@ -225,6 +225,7 @@ process_chain_ndvi = {
 # Import a Sentinel2A scene and compute the NDVI for a specific polygon
 # https://storage.googleapis.com/graas-geodata/rio.json
 # https://gdh-data-sandbox.ams3.digitaloceanspaces.com/rio.json
+# https://apps.mundialis.de/actinia_test_datasets/rio.json
 process_chain_ndvi_landsat = {
     "list": [
         {"id": "importer_1",
@@ -234,7 +235,7 @@ process_chain_ndvi_landsat = {
                                       "landsat_atcor": "dos1"},
                      "param": "map",
                      "value": "ignored"},
-                    {"import_descr": {"source": "https://storage.googleapis.com/graas-geodata/rio.json",
+                    {"import_descr": {"source": "https://apps.mundialis.de/actinia_test_datasets/rio.json",
                                       "type": "vector"},
                      "param": "map",
                      "value": "polygon"}]},

--- a/tests/test_async_processing_2.py
+++ b/tests/test_async_processing_2.py
@@ -29,9 +29,17 @@ import unittest
 from flask.json import dumps as json_dumps
 
 try:
-    from .test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+    from .test_resource_base import (
+        ActiniaResourceTestCaseBase,
+        URL_PREFIX,
+        additional_external_data
+    )
 except ModuleNotFoundError:
-    from test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+    from test_resource_base import (
+        ActiniaResourceTestCaseBase,
+        URL_PREFIX,
+        additional_external_data
+    )
 
 __license__ = "GPLv3"
 __author__ = "Sören Gebbert"
@@ -180,8 +188,9 @@ process_chain_ndvi = {
                                       "sentinel_band": "B08"},
                      "param": "map",
                      "value": "B08"},
-                    {"import_descr": {"source": "https://apps.mundialis.de/actinia_test_datasets/brazil_polygon.json",
-                                      "type": "vector"},
+                    {"import_descr": {
+                        "source": additional_external_data["brazil_json"],
+                        "type": "vector"},
                      "param": "map",
                      "value": "polygon"}]},
 
@@ -235,7 +244,7 @@ process_chain_ndvi_landsat = {
                                       "landsat_atcor": "dos1"},
                      "param": "map",
                      "value": "ignored"},
-                    {"import_descr": {"source": "https://apps.mundialis.de/actinia_test_datasets/rio.json",
+                    {"import_descr": {"source": additional_external_data["rio_json"],
                                       "type": "vector"},
                      "param": "map",
                      "value": "polygon"}]},

--- a/tests/test_async_processing_export_vector.py
+++ b/tests/test_async_processing_export_vector.py
@@ -69,7 +69,7 @@ vector_layer_buffer = {
         "module": "importer",
         "inputs": [{
             "import_descr": {
-                "source": "https://apps.mundialis.de/actinia_test_datasets/rio.json2",
+                "source": "https://apps.mundialis.de/actinia_test_datasets/rio.json",
                 "type": "vector"
             },
             "param": "map",

--- a/tests/test_async_processing_export_vector.py
+++ b/tests/test_async_processing_export_vector.py
@@ -28,9 +28,17 @@ import pytest
 import unittest
 from flask.json import dumps as json_dumps
 try:
-    from .test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+    from .test_resource_base import (
+        ActiniaResourceTestCaseBase,
+        URL_PREFIX,
+        additional_external_data
+    )
 except ModuleNotFoundError:
-    from test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+    from test_resource_base import (
+        ActiniaResourceTestCaseBase,
+        URL_PREFIX,
+        additional_external_data
+    )
 
 __license__ = "GPLv3"
 __author__ = "Sören Gebbert"
@@ -69,7 +77,7 @@ vector_layer_buffer = {
         "module": "importer",
         "inputs": [{
             "import_descr": {
-                "source": "https://apps.mundialis.de/actinia_test_datasets/rio.json",
+                "source": additional_external_data["rio_json"],
                 "type": "vector"
             },
             "param": "map",
@@ -112,7 +120,7 @@ vector_layer_clean = {
         "module": "importer",
         "inputs": [{
             "import_descr": {
-                "source": "https://apps.mundialis.de/actinia_test_datasets/rio.json",
+                "source": additional_external_data["rio_json"],
                 "type": "vector"
             },
             "param": "map",
@@ -175,7 +183,6 @@ class AsyncProcessTestCase(ActiniaResourceTestCaseBase):
             self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
             self.assertEqual(rv.mimetype, "application/zip", "Wrong mimetype %s" % rv.mimetype)
 
-    @pytest.mark.dev
     def test_vector_buffer(self):
         rv = self.server.post(URL_PREFIX + '/locations/latlong_wgs84/processing_async_export',
                               headers=self.admin_auth_header,

--- a/tests/test_async_processing_export_vector.py
+++ b/tests/test_async_processing_export_vector.py
@@ -24,6 +24,7 @@
 """
 Tests: AsyncProcess test case
 """
+import pytest
 import unittest
 from flask.json import dumps as json_dumps
 try:
@@ -68,7 +69,7 @@ vector_layer_buffer = {
         "module": "importer",
         "inputs": [{
             "import_descr": {
-                "source": "https://storage.googleapis.com/graas-geodata/rio.json",
+                "source": "https://apps.mundialis.de/actinia_test_datasets/rio.json",
                 "type": "vector"
             },
             "param": "map",
@@ -111,7 +112,7 @@ vector_layer_clean = {
         "module": "importer",
         "inputs": [{
             "import_descr": {
-                "source": "https://storage.googleapis.com/graas-geodata/rio.json",
+                "source": "https://apps.mundialis.de/actinia_test_datasets/rio.json",
                 "type": "vector"
             },
             "param": "map",
@@ -174,12 +175,12 @@ class AsyncProcessTestCase(ActiniaResourceTestCaseBase):
             self.assertEqual(rv.status_code, 200, "HTML status code is wrong %i" % rv.status_code)
             self.assertEqual(rv.mimetype, "application/zip", "Wrong mimetype %s" % rv.mimetype)
 
+    @pytest.mark.dev
     def test_vector_buffer(self):
         rv = self.server.post(URL_PREFIX + '/locations/latlong_wgs84/processing_async_export',
                               headers=self.admin_auth_header,
                               data=json_dumps(vector_layer_buffer),
                               content_type="application/json")
-
         resp = self.waitAsyncStatusAssertHTTP(rv, headers=self.admin_auth_header,
                                               http_status=200, status="finished")
 

--- a/tests/test_async_processing_export_vector.py
+++ b/tests/test_async_processing_export_vector.py
@@ -69,7 +69,7 @@ vector_layer_buffer = {
         "module": "importer",
         "inputs": [{
             "import_descr": {
-                "source": "https://apps.mundialis.de/actinia_test_datasets/rio.json",
+                "source": "https://apps.mundialis.de/actinia_test_datasets/rio.json2",
                 "type": "vector"
             },
             "param": "map",

--- a/tests/test_async_processing_import_export.py
+++ b/tests/test_async_processing_import_export.py
@@ -28,9 +28,17 @@ import os
 import unittest
 from flask.json import dumps as json_dumps
 try:
-    from .test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+    from .test_resource_base import (
+        ActiniaResourceTestCaseBase,
+        URL_PREFIX,
+        additional_external_data
+    )
 except ModuleNotFoundError:
-    from test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+    from test_resource_base import (
+        ActiniaResourceTestCaseBase,
+        URL_PREFIX,
+        additional_external_data
+    )
 
 try:
     import actinia_stac_plugin
@@ -48,8 +56,7 @@ process_chain_raster_import_export = {
     'list': [{'flags': 'a',
               'id': 'r_slope_aspect_1',
               'inputs': [{'import_descr': {
-                  'source': 'https://apps.mundialis.de/actinia_test_datasets/'
-                            'elev_ned_30m.tif',
+                  'source': additional_external_data["elev_ned_30m_tif"],
                   'type': 'raster'},
                   'param': 'elevation',
                   'value': 'elev_ned_30m'},
@@ -72,7 +79,7 @@ process_chain_raster_import_export = {
 
 process_chain_raster_import_info = {
     'list': [{'id': 'r_info',
-              'inputs': [{'import_descr': {'source': 'https://apps.mundialis.de/actinia_test_datasets/elev_ned_30m.tif',
+              'inputs': [{'import_descr': {'source': additional_external_data["elev_ned_30m_tif"],
                                            'type': 'raster'},
                           'param': 'map',
                           'value': 'elev_ned_30m'}],
@@ -83,7 +90,7 @@ process_chain_raster_import_info = {
 process_chain_raster_import_error_no_file = {
     'list': [{'id': 'r_info',
               'inputs': [
-                  {'import_descr': {'source': 'https://apps.mundialis.de/actinia_test_datasets/elev_ned_30m_nope.tif',
+                  {'import_descr': {'source': additional_external_data["elev_ned_30m_nope_tif"],
                                     'type': 'raster'},
                       'param': 'map',
                       'value': 'elev_ned_30m'}, ],
@@ -93,7 +100,7 @@ process_chain_raster_import_error_no_file = {
 
 process_chain_vector_import_info = {
     'list': [{'id': 'v_info',
-              'inputs': [{'import_descr': {'source': 'https://apps.mundialis.de/actinia_test_datasets/polygon.gml',
+              'inputs': [{'import_descr': {'source': additional_external_data["polygon_gml"],
                                            'type': 'vector'},
                           'param': 'map',
                           'value': 'polygon'}],
@@ -160,7 +167,7 @@ process_chain_sentinel_import_export = {
                                            'sentinel_band': 'B01'},
                           'param': 'map',
                           'value': 'sentinel_map'},
-                         {'import_descr': {'source': 'https://apps.mundialis.de/actinia_test_datasets/elev_ned_30m.tif',
+                         {'import_descr': {'source': additional_external_data["elev_ned_30m_tif"],
                                            'type': 'raster'},
                           'param': 'map',
                           'value': 'elev_ned_30m'}],

--- a/tests/test_async_processing_import_export.py
+++ b/tests/test_async_processing_import_export.py
@@ -48,7 +48,8 @@ process_chain_raster_import_export = {
     'list': [{'flags': 'a',
               'id': 'r_slope_aspect_1',
               'inputs': [{'import_descr': {
-                  'source': 'https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif',
+                  'source': 'https://apps.mundialis.de/actinia_test_datasets/'
+                            'elev_ned_30m.tif',
                   'type': 'raster'},
                   'param': 'elevation',
                   'value': 'elev_ned_30m'},
@@ -68,34 +69,10 @@ process_chain_raster_import_export = {
               'params': [],
               'stdin': 'r_slope_aspect_1::stderr'}],
     'version': '1'}
-#
-# [
-#     {'module' : 'r.slope.aspect',
-#      'id'     : 'r_slope_aspect_1',
-#      'inputs' : [
-#          {'import_descr': {'source': 'https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif',
-#                            'type'  : 'raster'},
-#           'param'       : 'elevation',
-#           'value'       : 'elev_ned_30m'},
-#          {'param': 'format', 'value': 'degree'},
-#          {'param': 'precision', 'value': 'DCELL'}
-#      ],
-#      'outputs': [
-#          {'param' : 'slope', 'value': 'elev_ned_30m_slope',
-#           'export': {'format': 'GTiff', 'type': 'raster'}},
-#          {'param' : 'aspect', 'value': 'elev_ned_30m_aspect',
-#           'export': {'format': 'GTiff', 'type': 'raster'}}
-#      ]
-#     },
-#     {'exe'  : '/bin/cat',
-#      'id'   : 'cat_1',
-#      'stdin': 'r_slope_aspect_1::stderr'
-#     }
-# ]
 
 process_chain_raster_import_info = {
     'list': [{'id': 'r_info',
-              'inputs': [{'import_descr': {'source': 'https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif',
+              'inputs': [{'import_descr': {'source': 'https://apps.mundialis.de/actinia_test_datasets/elev_ned_30m.tif',
                                            'type': 'raster'},
                           'param': 'map',
                           'value': 'elev_ned_30m'}],
@@ -106,7 +83,7 @@ process_chain_raster_import_info = {
 process_chain_raster_import_error_no_file = {
     'list': [{'id': 'r_info',
               'inputs': [
-                  {'import_descr': {'source': 'https://storage.googleapis.com/graas-geodata/elev_ned_30m_nope.tif',
+                  {'import_descr': {'source': 'https://apps.mundialis.de/actinia_test_datasets/elev_ned_30m_nope.tif',
                                     'type': 'raster'},
                       'param': 'map',
                       'value': 'elev_ned_30m'}, ],
@@ -116,7 +93,7 @@ process_chain_raster_import_error_no_file = {
 
 process_chain_vector_import_info = {
     'list': [{'id': 'v_info',
-              'inputs': [{'import_descr': {'source': 'https://storage.googleapis.com/graas-geodata/polygon.gml',
+              'inputs': [{'import_descr': {'source': 'https://apps.mundialis.de/actinia_test_datasets/polygon.gml',
                                            'type': 'vector'},
                           'param': 'map',
                           'value': 'polygon'}],
@@ -183,7 +160,7 @@ process_chain_sentinel_import_export = {
                                            'sentinel_band': 'B01'},
                           'param': 'map',
                           'value': 'sentinel_map'},
-                         {'import_descr': {'source': 'https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif',
+                         {'import_descr': {'source': 'https://apps.mundialis.de/actinia_test_datasets/elev_ned_30m.tif',
                                            'type': 'raster'},
                           'param': 'map',
                           'value': 'elev_ned_30m'}],

--- a/tests/test_geodata_import.py
+++ b/tests/test_geodata_import.py
@@ -96,7 +96,7 @@ class GeoDataDownloadImportSupportTestCase(unittest.TestCase):
 
     def test_download_commands_gml(self):
 
-        gml = "https://storage.googleapis.com/graas-geodata/census_wake2000.gml"
+        gml = "https://apps.mundialis.de/actinia_test_datasets/census_wake2000.gml"
 
         gddl = GeoDataDownloadImportSupport(config=global_config,
                                             temp_file_path="/tmp",
@@ -124,10 +124,10 @@ class GeoDataDownloadImportSupportTestCase(unittest.TestCase):
 
         url_list = []
 
-        gml = "https://storage.googleapis.com/graas-geodata/census_wake2000.gml"
-        gml_zip = "https://storage.googleapis.com/graas-geodata/census_wake2000.zip"
-        tif = "https://storage.googleapis.com/graas-geodata/geology_30m.tif"
-        tif_zip = "https://storage.googleapis.com/graas-geodata/geology_30m.zip"
+        gml = "https://apps.mundialis.de/actinia_test_datasets/census_wake2000.gml"
+        gml_zip = "https://apps.mundialis.de/actinia_test_datasets/census_wake2000.zip"
+        tif = "https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif"
+        tif_zip = "https://apps.mundialis.de/actinia_test_datasets/geology_30m.zip"
 
         url_list.append(gml_zip)
         url_list.append(tif_zip)
@@ -154,12 +154,12 @@ class GeoDataDownloadImportSupportTestCase(unittest.TestCase):
     def test_download_commands_tif(self):
 
         tif_list = []
-        tif_list.append("https://storage.googleapis.com/graas-geodata/geology_30m.tif")
-        tif_list.append("https://storage.googleapis.com/graas-geodata/geology_30m.tif")
-        tif_list.append("https://storage.googleapis.com/graas-geodata/geology_30m.tif")
-        tif_list.append("https://storage.googleapis.com/graas-geodata/geology_30m.tif")
-        tif_list.append("https://storage.googleapis.com/graas-geodata/geology_30m.tif")
-        tif_list.append("https://storage.googleapis.com/graas-geodata/geology_30m.tif")
+        tif_list.append("https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif")
+        tif_list.append("https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif")
+        tif_list.append("https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif")
+        tif_list.append("https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif")
+        tif_list.append("https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif")
+        tif_list.append("https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif")
 
         gddl = GeoDataDownloadImportSupport(config=global_config,
                                             temp_file_path="/tmp",

--- a/tests/test_geodata_import.py
+++ b/tests/test_geodata_import.py
@@ -32,6 +32,12 @@ import subprocess
 import os
 import shutil
 
+try:
+    from .test_resource_base import additional_external_data
+except ModuleNotFoundError:
+    from test_resource_base import additional_external_data
+
+
 __license__ = "GPLv3"
 __author__ = "Sören Gebbert"
 __copyright__ = "Copyright 2016-2018, Sören Gebbert and mundialis GmbH & Co. KG"
@@ -96,7 +102,7 @@ class GeoDataDownloadImportSupportTestCase(unittest.TestCase):
 
     def test_download_commands_gml(self):
 
-        gml = "https://apps.mundialis.de/actinia_test_datasets/census_wake2000.gml"
+        gml = additional_external_data["census_wake2000_gml"]
 
         gddl = GeoDataDownloadImportSupport(config=global_config,
                                             temp_file_path="/tmp",
@@ -124,10 +130,10 @@ class GeoDataDownloadImportSupportTestCase(unittest.TestCase):
 
         url_list = []
 
-        gml = "https://apps.mundialis.de/actinia_test_datasets/census_wake2000.gml"
-        gml_zip = "https://apps.mundialis.de/actinia_test_datasets/census_wake2000.zip"
-        tif = "https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif"
-        tif_zip = "https://apps.mundialis.de/actinia_test_datasets/geology_30m.zip"
+        gml = additional_external_data["census_wake2000_gml"]
+        gml_zip = additional_external_data["census_wake2000_zip"]
+        tif = additional_external_data["geology_30m_tif"]
+        tif_zip = additional_external_data["geology_30m_zip"]
 
         url_list.append(gml_zip)
         url_list.append(tif_zip)
@@ -154,12 +160,12 @@ class GeoDataDownloadImportSupportTestCase(unittest.TestCase):
     def test_download_commands_tif(self):
 
         tif_list = []
-        tif_list.append("https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif")
-        tif_list.append("https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif")
-        tif_list.append("https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif")
-        tif_list.append("https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif")
-        tif_list.append("https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif")
-        tif_list.append("https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif")
+        tif_list.append(additional_external_data["geology_30m_tif"])
+        tif_list.append(additional_external_data["geology_30m_tif"])
+        tif_list.append(additional_external_data["geology_30m_tif"])
+        tif_list.append(additional_external_data["geology_30m_tif"])
+        tif_list.append(additional_external_data["geology_30m_tif"])
+        tif_list.append(additional_external_data["geology_30m_tif"])
 
         gddl = GeoDataDownloadImportSupport(config=global_config,
                                             temp_file_path="/tmp",

--- a/tests/test_job_resumption.py
+++ b/tests/test_job_resumption.py
@@ -37,9 +37,17 @@ from actinia_core.core.common.process_queue import create_process_queue
 from actinia_core.core.common.config import global_config
 
 try:
-    from .test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+    from .test_resource_base import (
+        ActiniaResourceTestCaseBase,
+        URL_PREFIX,
+        additional_external_data
+    )
 except ModuleNotFoundError:
-    from test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+    from test_resource_base import (
+        ActiniaResourceTestCaseBase,
+        URL_PREFIX,
+        additional_external_data
+    )
 
 __license__ = "GPLv3"
 __author__ = "Anika Weinmann"
@@ -121,8 +129,7 @@ process_chain_3_importer = {
             "inputs": [
                 {
                   "import_descr": {
-                      "source": "https://apps.mundialis.de/actinia_test_"
-                      "datasets/elev_ned_30m.tif",
+                      "source": additional_external_data["elev_ned_30m_tif"],
                       "type": "raster"
                   },
                     "param": "raster",
@@ -149,8 +156,7 @@ process_chain_3_importer = {
             "inputs": [
                 {
                     "import_descr": {
-                        "source": "https://raw.githubusercontent.com/mmacata/"
-                                  "pagestest/gh-pages/pointInBonn.geojson",
+                        "source": additional_external_data["pointInBonn"],
                         "type": "vector"
                     },
                     "param": "map",
@@ -158,8 +164,7 @@ process_chain_3_importer = {
                 },
                 {
                     "import_descr": {
-                        "source": "https://apps.mundialis.de/actinia_test_"
-                                  "datasets/geology_30m.tif",
+                        "source": additional_external_data["geology_30m_tif"],
                         "type": "raster"
                     },
                     "param": "map",

--- a/tests/test_job_resumption.py
+++ b/tests/test_job_resumption.py
@@ -121,8 +121,8 @@ process_chain_3_importer = {
             "inputs": [
                 {
                   "import_descr": {
-                      "source": "https://storage.googleapis.com/graas-"
-                      "geodata/elev_ned_30m.tif",
+                      "source": "https://apps.mundialis.de/actinia_test_"
+                      "datasets/elev_ned_30m.tif",
                       "type": "raster"
                   },
                     "param": "raster",
@@ -158,8 +158,8 @@ process_chain_3_importer = {
                 },
                 {
                     "import_descr": {
-                        "source": "https://storage.googleapis.com/graas-"
-                                  "geodata/geology_30m.tif",
+                        "source": "https://apps.mundialis.de/actinia_test_"
+                                  "datasets/geology_30m.tif",
                         "type": "raster"
                     },
                     "param": "map",

--- a/tests/test_raster_upload.py
+++ b/tests/test_raster_upload.py
@@ -44,7 +44,8 @@ class UploadRasterLayerTestCase(ActiniaResourceTestCaseBase):
     mapset = "PERMANENT"
     tmp_mapset = "mapset_upload"
     raster = "elev_ned_30m"
-    raster_url = f"https://storage.googleapis.com/graas-geodata/{raster}.tif"
+    raster_url = "https://apps.mundialis.de/actinia_test_datasets/" \
+        "elev_ned_30m.tif"
     local_raster = f"/tmp/{raster}.tif"
 
     ref_info = {'cells': '225000', 'cols': '500', 'east': '645000', 'ewres': '30',

--- a/tests/test_raster_upload.py
+++ b/tests/test_raster_upload.py
@@ -28,9 +28,17 @@ import os
 import unittest
 import requests
 try:
-    from .test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+    from .test_resource_base import (
+        ActiniaResourceTestCaseBase,
+        URL_PREFIX,
+        additional_external_data
+    )
 except Exception:
-    from test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+    from test_resource_base import (
+        ActiniaResourceTestCaseBase,
+        URL_PREFIX,
+        additional_external_data
+    )
 
 __license__ = "GPLv3"
 __author__ = "Anika Weinmann, Guido Riembauer"
@@ -44,8 +52,7 @@ class UploadRasterLayerTestCase(ActiniaResourceTestCaseBase):
     mapset = "PERMANENT"
     tmp_mapset = "mapset_upload"
     raster = "elev_ned_30m"
-    raster_url = "https://apps.mundialis.de/actinia_test_datasets/" \
-        "elev_ned_30m.tif"
+    raster_url = additional_external_data["elev_ned_30m_tif"]
     local_raster = f"/tmp/{raster}.tif"
 
     ref_info = {'cells': '225000', 'cols': '500', 'east': '645000', 'ewres': '30',

--- a/tests/test_resource_base.py
+++ b/tests/test_resource_base.py
@@ -33,10 +33,9 @@ from actinia_core.core.common.config import global_config
 from actinia_core.endpoints import create_endpoints
 
 __license__ = "GPLv3"
-__author__ = "Sören Gebbert"
-__copyright__ = "Copyright 2016-2019, Sören Gebbert and mundialis GmbH & Co. KG"
+__author__ = "Sören Gebbert, Anika Weinmann"
+__copyright__ = "Copyright 2016-2022, Sören Gebbert and mundialis GmbH & Co. KG"
 __maintainer__ = "Sören Gebbert"
-__email__ = "soerengebbert@googlemail.com"
 
 # Create endpoints
 create_endpoints()
@@ -52,6 +51,19 @@ if "ACTINIA_SERVER_TEST" in os.environ:
 # Set this variable to use a actinia config file in a docker container
 if "ACTINIA_CUSTOM_TEST_CFG" in os.environ:
     custom_actinia_cfg = str(os.environ["ACTINIA_CUSTOM_TEST_CFG"])
+
+additional_external_data = {
+    "rio_json": "https://apps.mundialis.de/actinia_test_datasets/rio.json",
+    "brazil_json": "https://apps.mundialis.de/actinia_test_datasets/brazil_polygon.json",
+    "elev_ned_30m_tif": "https://apps.mundialis.de/actinia_test_datasets/elev_ned_30m.tif",
+    "elev_ned_30m_nope_tif": "https://apps.mundialis.de/actinia_test_datasets/elev_ned_30m_nope.tif",
+    "polygon_gml": "https://apps.mundialis.de/actinia_test_datasets/polygon.gml",
+    "census_wake2000_gml": "https://apps.mundialis.de/actinia_test_datasets/census_wake2000.gml",
+    "census_wake2000_zip": "https://apps.mundialis.de/actinia_test_datasets/census_wake2000.zip",
+    "geology_30m_tif": "https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif",
+    "geology_30m_zip": "https://apps.mundialis.de/actinia_test_datasets/geology_30m.zip",
+    "pointInBonn": "https://raw.githubusercontent.com/mmacata/pagestest/gh-pages/pointInBonn.geojson"
+}
 
 
 def setup_environment():

--- a/tests/test_resource_base.py
+++ b/tests/test_resource_base.py
@@ -62,7 +62,7 @@ additional_external_data = {
     "census_wake2000_zip": "https://apps.mundialis.de/actinia_test_datasets/census_wake2000.zip",
     "geology_30m_tif": "https://apps.mundialis.de/actinia_test_datasets/geology_30m.tif",
     "geology_30m_zip": "https://apps.mundialis.de/actinia_test_datasets/geology_30m.zip",
-    "pointInBonn": "https://raw.githubusercontent.com/mmacata/pagestest/gh-pages/pointInBonn.geojson"
+    "pointInBonn": "https://apps.mundialis.de/actinia_test_datasets/pointInBonn.geojson"
 }
 
 

--- a/tests/unittests/test_version.py
+++ b/tests/unittests/test_version.py
@@ -109,4 +109,4 @@ def test_find_additional_version_info(env_value, expected):
         if 'ACTINIA_ADDITIONAL_VERSION_INFO' in os.environ:
             del os.environ['ACTINIA_ADDITIONAL_VERSION_INFO']
     test = find_additional_version_info()
-    assert test == expected +'1', "Additional version is not right"
+    assert test == expected, "Additional version is not right"

--- a/tests/unittests/test_version.py
+++ b/tests/unittests/test_version.py
@@ -109,4 +109,4 @@ def test_find_additional_version_info(env_value, expected):
         if 'ACTINIA_ADDITIONAL_VERSION_INFO' in os.environ:
             del os.environ['ACTINIA_ADDITIONAL_VERSION_INFO']
     test = find_additional_version_info()
-    assert test == expected, "Additional version is not right"
+    assert test == expected +'1', "Additional version is not right"

--- a/tests_with_redis.sh
+++ b/tests_with_redis.sh
@@ -24,5 +24,9 @@ else
   python3 setup.py test
 fi
 
+TEST_RES=$?
+
 # stop redis server
 redis-cli shutdown
+
+return $TEST_RES


### PR DESCRIPTION
- use test data sets from apps.mundialis.de
- all addional data sets are defined in `test_resource_base.py`
- script to run integration tests is fixed so that it returns the test exit code and the GHA pipeline will fail if a test fails