### PR TITLE
Retry webhook

### DIFF
--- a/scripts/webhook-server
+++ b/scripts/webhook-server
@@ -62,7 +62,7 @@ def shutdown_server():
 @flask_app.route('/shutdown', methods=['GET'])
 def shutdown():
     shutdown_server()
-    return 'Server shutting down...'
+    return make_response(jsonify("Server shutting down..."), 200)
 
 
 def main():

--- a/scripts/webhook-server
+++ b/scripts/webhook-server
@@ -30,10 +30,9 @@ from pprint import pprint
 from flask import Flask, make_response, jsonify, request, json
 
 __license__    = "GPLv3"
-__author__     = "Soeren Gebbert"
-__copyright__  = "Copyright 2016-2018, Soeren Gebbert and mundialis GmbH & Co. KG"
-__maintainer__ = "Soeren Gebbert"
-__email__      = "soerengebbert@googlemail.com"
+__author__     = "Soeren Gebbert, Anika Weinmann"
+__copyright__  = "Copyright 2016-2022, mundialis GmbH & Co. KG"
+__maintainer__ = "mundialis GmbH & Co. KG"
 
 
 flask_app = Flask(__name__)
@@ -53,6 +52,19 @@ def update():
     return make_response(jsonify("OK"), 200)
 
 
+def shutdown_server():
+    func = request.environ.get('werkzeug.server.shutdown')
+    if func is None:
+        raise RuntimeError('Not running with the Werkzeug Server')
+    func()
+
+
+@flask_app.route('/shutdown', methods = ['GET'])
+def shutdown():
+    shutdown_server()
+    return 'Server shutting down...'
+
+
 def main():
 
     parser = argparse.ArgumentParser(description='Start a REST webhook server that exposes a two GET/POST endpoint '
@@ -66,12 +78,9 @@ def main():
     parser.add_argument("--port", type=int, required=False, default=5005,
                         help="The port that should be used for the webhook server")
 
-    parser.add_argument("--debug", type=bool, required=False, default=True,
-                        help="Set True to activate debugging")
-
     args = parser.parse_args()
 
-    flask_app.run(host=args.host, port=args.port, debug=args.debug)
+    flask_app.run(host=args.host, port=args.port)
 
 
 if __name__ == '__main__':

--- a/scripts/webhook-server-broken
+++ b/scripts/webhook-server-broken
@@ -62,7 +62,7 @@ def shutdown_server():
 @flask_app.route('/shutdown', methods=['GET'])
 def shutdown():
     shutdown_server()
-    return 'Server shutting down...'
+    return make_response(jsonify("Server shutting down..."), 200)
 
 
 def main():

--- a/scripts/webhook-server-broken
+++ b/scripts/webhook-server-broken
@@ -42,7 +42,7 @@ flask_app = Flask(__name__)
 def finished():
     if request.get_json():
         pprint(json.loads(request.get_json()))
-    return make_response(jsonify("OK"), 200)
+    shutdown_server()
 
 
 @flask_app.route('/webhook/update', methods=['GET', 'POST'])

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -31,8 +31,8 @@ import ast
 
 __license__ = "GPLv3"
 __author__ = "Sören Gebbert"
-__copyright__ = "Copyright 2016-2018, Sören Gebbert and mundialis GmbH & Co. KG"
-__maintainer__ = "mundialis"
+__copyright__ = "Copyright 2016-2022, Sören Gebbert and mundialis GmbH & Co. KG"
+__maintainer__ = "mundialis GmbH & Co. KG"
 
 if os.environ.get('DEFAULT_CONFIG_PATH'):
     DEFAULT_CONFIG_PATH = os.environ['DEFAULT_CONFIG_PATH']
@@ -225,6 +225,13 @@ class Configuration(object):
         # The Google Cloud Storage bucket to store user resources
         self.GCS_RESOURCE_BUCKET = ""
 
+        """
+        WEBHOOK
+        """
+        # Webhook finished retry
+        self.WEBHOOK_RETRIES = 3
+        self.WEBHOOK_SLEEP = 10
+
     def __str__(self):
         string = ""
         for entry in dir(self):
@@ -317,6 +324,10 @@ class Configuration(object):
                    self.GOOGLE_APPLICATION_CREDENTIALS)
         config.set('GCS', 'GCS_RESOURCE_BUCKET', self.GCS_RESOURCE_BUCKET)
         config.set('GCS', 'GOOGLE_CLOUD_PROJECT', self.GOOGLE_CLOUD_PROJECT)
+
+        config.add_section('WEBHOOK')
+        config.set('WEBHOOK', 'WEBHOOK_RETRIES', self.WEBHOOK_RETRIES)
+        config.set('WEBHOOK', 'WEBHOOK_SLEEP', self.WEBHOOK_SLEEP)
 
         with open(path, 'w') as configfile:
             config.write(configfile)
@@ -478,6 +489,14 @@ class Configuration(object):
                 if config.has_option("AWS_S3", "S3_AWS_RESOURCE_BUCKET"):
                     self.S3_AWS_RESOURCE_BUCKET = config.get(
                         "AWS_S3", "S3_AWS_RESOURCE_BUCKET")
+
+            if config.has_section("WEBHOOK"):
+                if config.has_option("WEBHOOK", "WEBHOOK_RETRIES"):
+                    self.WEBHOOK_RETRIES = config.get(
+                        "WEBHOOK", "WEBHOOK_RETRIES")
+                if config.has_option("WEBHOOK", "WEBHOOK_SLEEP"):
+                    self.WEBHOOK_SLEEP = config.get(
+                        "WEBHOOK", "WEBHOOK_SLEEP")
 
         def print_warning(cfg_section, cfg_key, file_val=None, env_val=None):
             if env_val is None:

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -326,8 +326,8 @@ class Configuration(object):
         config.set('GCS', 'GOOGLE_CLOUD_PROJECT', self.GOOGLE_CLOUD_PROJECT)
 
         config.add_section('WEBHOOK')
-        config.set('WEBHOOK', 'WEBHOOK_RETRIES', self.WEBHOOK_RETRIES)
-        config.set('WEBHOOK', 'WEBHOOK_SLEEP', self.WEBHOOK_SLEEP)
+        config.set('WEBHOOK', 'WEBHOOK_RETRIES', str(self.WEBHOOK_RETRIES))
+        config.set('WEBHOOK', 'WEBHOOK_SLEEP', str(self.WEBHOOK_SLEEP))
 
         with open(path, 'w') as configfile:
             config.write(configfile)

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -229,7 +229,7 @@ class Configuration(object):
         WEBHOOK
         """
         # Webhook finished retry
-        self.WEBHOOK_RETRIES = 3
+        self.WEBHOOK_RETRIES = 6
         self.WEBHOOK_SLEEP = 10
 
     def __str__(self):

--- a/src/actinia_core/rest/ephemeral_processing.py
+++ b/src/actinia_core/rest/ephemeral_processing.py
@@ -60,7 +60,7 @@ from actinia_core.rest.resource_base import ResourceBase
 
 __license__ = "GPLv3"
 __author__ = "Sören Gebbert, Anika Weinmann"
-__copyright__ = "Copyright 2016-2021, Sören Gebbert and mundialis GmbH & Co. KG"
+__copyright__ = "Copyright 2016-2022, Sören Gebbert and mundialis GmbH & Co. KG"
 __maintainer__ = "mundialis"
 
 
@@ -575,20 +575,24 @@ class EphemeralProcessing(object):
         retry = 0
         while webhook_not_reached is True and retry < webhook_retries:
             retry += 1
-            if self.webhook_auth:
-                # username is expected to be without colon (':')
-                r = requests.post(
-                    webhook_url, json=json.dumps(response_model),
-                    auth=HTTPBasicAuth(
-                        self.webhook_auth.split(':')[0],
-                        ':'.join(self.webhook_auth.split(':')[1:])))
-            else:
-                r = requests.post(webhook_url, json=json.dumps(response_model))
-            if r.status_code not in [200, 204]:
+            try:
+                if self.webhook_auth:
+                    # username is expected to be without colon (':')
+                    resp = requests.post(
+                        webhook_url, json=json.dumps(response_model),
+                        auth=HTTPBasicAuth(
+                            self.webhook_auth.split(':')[0],
+                            ':'.join(self.webhook_auth.split(':')[1:])),
+                        timeout=10)
+                else:
+                    resp = requests.post(webhook_url, json=json.dumps(response_model),
+                                         timeout=10)
+                if not (500 <= resp.status_code and resp.status_code < 600):
+                    webhook_not_reached = False
+            except Exception:
                 time.sleep(webhook_sleep)
-            else:
-                webhook_not_reached = False
-        if r.status_code not in [200, 204]:
+        if ((webhook_not_reached is False and resp.status_code not in [200, 204])
+                or webhook_not_reached is True):
             raise AsyncProcessError(
                 "Unable to access %s webhook URL %s" % (type, webhook_url))
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -127,20 +127,21 @@ class WebhookTestCase(ActiniaResourceTestCaseBase):
         resp_data2 = json_loads(rv2.data)
         return resp_data2
 
-    @pytest.mark.dev
-    def test_started_webhook(self):
-        """Test the started webhook via a actinia process."""
-        time.sleep(10)
-        resp = None
-        while resp is None or resp.status_code != 200:
-            resp = requests.get(f'http://0.0.0.0:{port}/webhook/finished')
-            time.sleep(3)
-        tm = Template(json_dumps(pc))
-        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/processing_async_export',
-                              headers=self.admin_auth_header,
-                              data=tm.render(sleep=1),
-                              content_type="application/json")
-        self.waitAsyncStatusAssertHTTP(rv, headers=self.admin_auth_header)
+    # @pytest.mark.dev
+    # def test_started_webhook(self):
+    #     """Test the started webhook via a actinia process."""
+    #     # time.sleep(10)
+    #     # import pdb; pdb.set_trace()
+    #     resp = None
+    #     while resp is None or resp.status_code != 200:
+    #         resp = requests.get(f'http://0.0.0.0:{port}/webhook/finished')
+    #         time.sleep(3)
+    #     tm = Template(json_dumps(pc))
+    #     rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/processing_async_export',
+    #                           headers=self.admin_auth_header,
+    #                           data=tm.render(sleep=1),
+    #                           content_type="application/json")
+    #     self.waitAsyncStatusAssertHTTP(rv, headers=self.admin_auth_header)
 
     @pytest.mark.dev
     def test_finished_webhook_retries(self):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -25,15 +25,13 @@
 Tests: Async process test case
 """
 import unittest
-import pytest
+# import pytest
 from flask.json import loads as json_loads, dumps as json_dumps
-from flask import Flask, request, json, make_response, jsonify
 import requests
 from jinja2 import Template
-from pprint import pprint
 import os
 import time
-import subprocess
+
 try:
     from .test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
 except ModuleNotFoundError:
@@ -143,7 +141,6 @@ class WebhookTestCase(ActiniaResourceTestCaseBase):
     #                           content_type="application/json")
     #     self.waitAsyncStatusAssertHTTP(rv, headers=self.admin_auth_header)
 
-    @pytest.mark.dev
     def test_finished_webhook_retries(self):
         """Test the retry if the webhook can not be reached or returns a server
         error.

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -42,11 +42,12 @@ __author__ = "Anika Weinmann"
 __copyright__ = "Copyright 2022, mundialis GmbH & Co. KG"
 __maintainer__ = "mundialis GmbH & Co. KG"
 
+port = "5006"
 
 pc = {
     "version": 1,
-    "webhooks": {"finished": "http://0.0.0.0:5006/webhook/finished",
-                 "update": "http://0.0.0.0:5006/webhook/update"},
+    "webhooks": {"finished": f"http://0.0.0.0:{port}/webhook/finished",
+                 "update": f"http://0.0.0.0:{port}/webhook/update"},
     "list": [
         {
             "id": "1",
@@ -67,9 +68,6 @@ pc = {
         }
     ]
 }
-
-
-port = "5006"
 
 
 def startWebhook(sleeptime=10):
@@ -160,8 +158,9 @@ class WebhookTestCase(ActiniaResourceTestCaseBase):
         self.assertEqual(status, "running", "Actinia job is not 'running'!")
 
         # shutdown webhook and start broken finished webhook
-        webhook_resp = requests.get('http://0.0.0.0:5006/shutdown')
+        webhook_resp = requests.get(f"http://0.0.0.0:{port}/shutdown")
         self.assertEqual(webhook_resp.status_code, 200, "Shutdown of webhook failed!")
+        time.sleep(2)
         status_code = startBrokenWebhook(10)
         self.assertEqual(status_code, 200, "Broken webhook server is not running")
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+#######
+# actinia-core - an open source REST API for scalable, distributed, high
+# performance processing of geographical data that uses GRASS GIS for
+# computational tasks. For details, see https://actinia.mundialis.de/
+#
+# Copyright (c) 2016-2018 Sören Gebbert and mundialis GmbH & Co. KG
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#######
+
+"""
+Tests: Async process test case
+"""
+import unittest
+import pytest
+from flask.json import loads as json_loads, dumps as json_dumps
+from flask import Flask, request, json, make_response, jsonify
+import requests
+from jinja2 import Template
+from pprint import pprint
+import os
+import time
+import subprocess
+try:
+    from .test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+except ModuleNotFoundError:
+    from test_resource_base import ActiniaResourceTestCaseBase, URL_PREFIX
+
+__license__ = "GPLv3"
+__author__ = "Anika Weinmann"
+__copyright__ = "Copyright 2022, mundialis GmbH & Co. KG"
+__maintainer__ = "mundialis GmbH & Co. KG"
+
+
+pc = {
+    "version": 1,
+    "webhooks": {"finished": "http://0.0.0.0:5006/webhook/finished",
+                 "update": "http://0.0.0.0:5006/webhook/update"},
+    "list": [
+        {
+            "id": "1",
+            "exe": "/bin/sleep",
+            "params": ["{{ sleep }}"]
+        },
+        {
+            "id": "2",
+            "module": "g.region",
+            "inputs": [
+                {"param": "raster",
+                 "value": "elevation@PERMANENT"},
+                {"param": "res",
+                 "value": "10000"}
+            ],
+            "flags": "p",
+            "verbose": True
+        }
+    ]
+}
+
+
+port = "5006"
+
+
+def startWebhook(sleeptime=10):
+    inputlist = [
+        "/src/actinia_core/build/scripts-3.8/webhook-server",
+        "--host", "0.0.0.0", "--port", port, "&"]
+    os.system(" ".join(inputlist))
+    time.sleep(sleeptime)
+    resp = requests.get(f'http://0.0.0.0:{port}/webhook/finished')
+    return resp.status_code
+
+
+class BrokenWebhook(object):
+    """
+    Class with a broken webhook server for testsing. The finished webhook
+    return 500 to test the retries if the webhook server can not be reached or
+    return a server error code (500 - 599).
+    """
+
+    flask_app = Flask(__name__)
+
+    @flask_app.route('/webhook/finished', methods=['GET', 'POST'])
+    def finished(self):
+        if request.get_json():
+            pprint(json.loads(request.get_json()))
+
+        self.shutdown_server()
+
+    @flask_app.route('/webhook/update', methods=['GET', 'POST'])
+    def update(self):
+        if request.get_json():
+            pprint(json.loads(request.get_json()))
+        return make_response(jsonify("OK"), 200)
+
+    def run(self):
+        self.flask_app.run(host="0.0.0.0", port=port)
+
+    def shutdown_server(self):
+        func = request.environ.get('werkzeug.server.shutdown')
+        if func is None:
+            raise RuntimeError('Not running with the Werkzeug Server')
+        func()
+
+    @flask_app.route('/shutdown', methods=['GET'])
+    def shutdown(self):
+        self.shutdown_server()
+        return 'Server shutting down...'
+
+
+class WebhookTestCase(ActiniaResourceTestCaseBase):
+
+    def setUp(self):
+        # start a webhook server before the normal setUp
+        status_code = startWebhook()
+        self.assertEqual(status_code, 200, "Webhook server is not running")
+        super().setUp()
+
+    def tearDown(self):
+        # shutting down the webhook server
+        resp = requests.get(f'http://0.0.0.0:{port}/shutdown')
+        self.assertEqual(resp.status_code, 200, "Webhook server is not shutting down")
+
+    def poll_job(self, resp_data):
+        # poll an actinia job
+        rv_user_id = resp_data["user_id"]
+        rv_resource_id = resp_data["resource_id"]
+        rv2 = self.server.get(URL_PREFIX + "/resources/%s/%s"
+                              % (rv_user_id, rv_resource_id),
+                              headers=self.admin_auth_header)
+        resp_data2 = json_loads(rv2.data)
+        return resp_data2
+
+    # @pytest.mark.dev
+    def test_started_webhook(self):
+        """Test the started webhook via a actinia process."""
+        tm = Template(json_dumps(pc))
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/processing_async_export',
+                              headers=self.admin_auth_header,
+                              data=tm.render(sleep=1),
+                              content_type="application/json")
+        self.waitAsyncStatusAssertHTTP(rv, headers=self.admin_auth_header)
+
+    @pytest.mark.dev
+    def test_finished_webhook_retries(self):
+        """Test the retry if the webhook can not be reached or returns a server
+        error.
+        """
+        tm = Template(json_dumps(pc))
+        rv = self.server.post(URL_PREFIX + '/locations/nc_spm_08/processing_async_export',
+                              headers=self.admin_auth_header,
+                              data=tm.render(sleep=30),
+                              content_type="application/json")
+
+        # poll job and check if it is running
+        resp_data = json_loads(rv.data)
+        status = resp_data["status"]
+        while status == "accepted":
+            resp_data2 = self.poll_job(resp_data)
+            status = resp_data2["status"]
+        self.assertEqual(status, "running", "Actinia job is not 'running'!")
+
+        # shutdown webhook and start broken finished webhook
+        webhook_resp = requests.get('http://0.0.0.0:5006/shutdown')
+        self.assertEqual(webhook_resp.status_code, 200, "Shutdown of webhook failed!")
+        broken_webhook = BrokenWebhook()
+
+        broken_server_is_running = True
+        while broken_server_is_running is True:
+            try:
+                requests.get(f'http://0.0.0.0:{port}/webhook/finished')
+            except Exception:
+                broken_server_is_running = False
+                del broken_webhook
+
+        # restart webhook server
+        status_code = startWebhook(10)
+        self.assertEqual(status_code, 200, "Webhook server restart failed")
+
+        # check if job is finished
+        resp_data2 = self.poll_job(resp_data)
+        status = resp_data2["status"]
+        self.assertEqual(status, "finished", "Actinia job is not finished")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests_with_redis.sh
+++ b/tests_with_redis.sh
@@ -26,3 +26,6 @@ fi
 
 # stop redis server
 redis-cli shutdown
+
+# stop webhook server
+curl http://0.0.0.0:5005/shutdown


### PR DESCRIPTION
If a `finished_webhook` is set this is informed if the process is finished or has an error. Unit now this `finished_webhook` was only called once and when the connection fails the `finished_webhook` never get to know that the process is not running anymore.
This change make it configurable, that the `finished_webhook` can be retried. For this you can set in the `actinia.cfg` a WEBHOOK section like this:
```
[WEBHOOK]
WEBHOOK_RETRIES = 6
WEBHOOK_SLEEP = 10
```