### PR TITLE
CITATION.cff: citable actinia core source code with DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ abstract: "Actinia is an open source REST API for scalable, distributed, high pe
 message: "If you use this software, please cite it using the metadata from this file."
 type: software
 version: 3.0.0
-doi: "10.5281/zenodo.5865317"
+doi: "10.5281/zenodo.5864847"
 date-released: "2022-01-13"
 license: GPL-3.0
 repository-code: "https://github.com/mundialis/actinia_core"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,58 @@
+# This CITATION.cff file was generated with cffinit.
+
+cff-version: 1.2.0
+title: "actinia-core"
+abstract: "Actinia is an open source REST API for scalable, distributed, high performance processing of geographical data."
+message: "If you use this software, please cite it using the metadata from this file."
+type: software
+version: 3.0.0
+doi: "10.5281/zenodo.5865317"
+date-released: "2022-01-13"
+license: GPL-3.0
+repository-code: "https://github.com/mundialis/actinia_core"
+keywords:
+ - "cloud-based processing"
+ - "geospatial analysis"
+ - "Earth observation"
+ - "GIS"
+ - "REST API"
+ - "Open Source"
+ - "GRASS GIS"
+authors:
+  - given-names: Carmen
+    family-names: Tawalika
+    email: tawalika@mundialis.de
+    affiliation: mundialis GmbH & Co. KG
+  - given-names: Anika
+    family-names: Weinmann
+    affiliation: mundialis GmbH & Co. KG
+    email: weinmann@mundialis.de
+  - given-names: Guido
+    family-names: Riembauer
+    email: riembauer@mundialis.de
+    affiliation: mundialis GmbH & Co. KG
+  - given-names: Markus
+    family-names: Metz
+    email: metz@mundialis.de
+    affiliation: mundialis GmbH & Co. KG
+    orcid: 'https://orcid.org/0000-0002-4038-8754'
+  - given-names: Julia
+    family-names: Haas
+    email: haas@mundialis.de
+    affiliation: mundialis GmbH & Co. KG
+    orcid: 'https://orcid.org/0000-0002-6040-0669'
+  - given-names: Marc
+    family-names: Jansen
+    email: jansen@mundialis.de
+    affiliation: mundialis GmbH & Co. KG
+  - given-names: Jorge A.
+    family-names: Herrera Maldonado
+    email: herreram.jahm@gmail.com
+  - given-names: Sören
+    family-names: Gebbert
+    email: soerengebbert@gmail.com
+  - given-names: Markus
+    family-names: Neteler
+    email: neteler@mundialis.de
+    affiliation: mundialis GmbH & Co. KG
+    orcid: 'https://orcid.org/0000-0003-1916-1966'


### PR DESCRIPTION
The actinia code can now be cited and remains accessible through a permanently citable DOI. See:

https://github.com/mundialis/actinia_core/wiki#citing-actinia

Note:
- in case of a new actinia release, the following entries need to be updated in CITATION.cff first:
  - date-released
  - version
  - as needed, list of authors.

TODO:
- ~~consider removing the hardcoded `doi: ...` line since with a new release a new DOI will be assigned~~
  - replaced by generic actinia DOI
- ~~register GitHub-Zenodo.org connection for the autogenerating of new entries~~
  - https://guides.lib.berkeley.edu/citeyourcode
  - https://docs.github.com/en/repositories/archiving-a-github-repository/referencing-and-citing-content
     - The registration of GitHub-Zenodo.org connection for the autogenerating of new entries has been established.