### PR TITLE
export_strds: specify path to the directory where output is written

### DIFF
--- a/src/actinia_core/rest/ephemeral_processing_with_export.py
+++ b/src/actinia_core/rest/ephemeral_processing_with_export.py
@@ -321,6 +321,7 @@ class EphemeralProcessingWithExport(EphemeralProcessing):
             "input=%s" % strds_name,
             "format=%s" % format,
             "output=%s" % output_path,
+            "directory=%s" % self.temp_file_path,
             "compression=%s" % "gzip"
         ]
         # optimized for GTiff


### PR DESCRIPTION
By default, `t.rast.export` in `_export_strds()` uses the current directory for raster exports which can be dangerous. In actinia, output should be written to a temporary directory in the current temporary GRASS db, as in e.g. `_export_raster()`.

Important rule: if you don't know what the current working directory is, don't use it (esp. for large temporary files).