### PR TITLE
Simplify lint workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,6 +10,7 @@ max-line-length = 88
 exclude =
     .git,
     __pycache__,
+    build,
     .env,
     .eggs,
     .venv,
@@ -23,14 +24,15 @@ exclude =
     testsuite,
 
 per-file-ignores =
-    ./actinia_core/core/common/api_logger.py: F401
-    ./actinia_core/core/common/app.py: E402, E501
-    ./actinia_core/testsuite.py: F401
-    ./actinia_core/rest/ephemeral_processing.py: F401, W605
-    ./actinia_core/core/storage_interface_gcs.py: F401
-    ./actinia_core/main.py: F401
-    ./actinia_core/core/common/process_queue.py: F401
-    ./actinia_core/models/process_chain.py: W605
-    ./actinia_core/core/interim_results.py: W605
-    ./actinia_core/core/list_grass_modules.py: F821
-    ./actinia_core/core/common/aws_sentinel_interface.py: E501
+    ./src/actinia_core/core/common/api_logger.py: F401
+    ./src/actinia_core/core/common/app.py: E402, E501
+    ./src/actinia_core/testsuite.py: F401
+    ./src/actinia_core/rest/ephemeral_processing.py: F401, W605
+    ./src/actinia_core/core/storage_interface_gcs.py: F401
+    ./src/actinia_core/main.py: F401
+    ./src/actinia_core/core/common/process_queue.py: F401
+    ./src/actinia_core/models/process_chain.py: W605
+    ./src/actinia_core/core/interim_results.py: W605
+    ./src/actinia_core/core/list_grass_modules.py: F821
+    ./src/actinia_core/core/common/aws_sentinel_interface.py: E501
+    ./tests/*: E501, F401

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -23,9 +23,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8==3.8.0
-    - name: Run Flake8 on src/ and tests/
+    - name: Run Flake8
       run: |
-        cd src
-        flake8 --config=../.flake8 --count --statistics --show-source --jobs=$(nproc) .
-        cd ../tests
-        flake8 --config=../.flake8 --ignore E501,F401 --count --statistics --show-source --jobs=$(nproc) .        
+        flake8 --config=.flake8 --count --statistics --show-source --jobs=$(nproc) .


### PR DESCRIPTION
This PR suggests to adjust the `.flake8` file for more easy local linting. It also adjusts the github workflow so that it behaves as usual.
It enhances local linting because now it is possible to stay in the main folder and lint everything at once with e.g.

`flake8 --count --statistics --show-source --jobs=4 .`
 