### PR TITLE
Fix wheel build in gha

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ jobs:
       #     python-version: '3.x'
       - name: Install dependencies
         run: |
-          apt-get update && apt-get install python3 python3-pip python3-venv libgdal-dev -y
+          sudo apt-get update && apt-get install python3 python3-pip python3-venv libgdal-dev -y
           pip3 install gdal
           pip3 install rasterio==1.2.10
           # apt install git python3-venv -y

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: alpine-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          apt update && apt install python3 python3-pip -y
+          apt update && apt install python3 python3-pip libgdal-dev -y
           pip3 install gdal
           pip3 install rasterio==1.2.10
           # apt install git python3-venv -y

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,7 +11,6 @@ name: Upload Python Package
 on:
   release:
     types: [published]
-on:
   push:
     branches: [wheel]
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,8 +11,6 @@ name: Upload Python Package
 on:
   release:
     types: [published]
-  push:
-    branches: [wheel]
 
 jobs:
   deploy:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,15 +21,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
       - name: Install dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update && sudo apt-get install python3 python3-pip libgdal-dev -y
-          pip3 install rasterio==1.2.10
+          sudo apt-get update && sudo apt-get install python3 python3-pip python3-venv libgdal-dev -y
           pip3 install build
       - name: Build package
         run: python3 -m build --outdir build .

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           # sudo apt-get update && sudo apt-get install python3 python3-pip python3-venv libgdal-dev -y
+          cat /etc/*-release
           apk update && apk add python3 python3-pip python3-venv libgdal-dev -y
           pip3 install gdal
           pip3 install rasterio==1.2.10

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ jobs:
       #     python-version: '3.x'
       - name: Install dependencies
         run: |
-          apt update && apt install python3 python3-pip python3-venv libgdal-dev -y
+          apt-get update && apt-get install python3 python3-pip python3-venv libgdal-dev -y
           pip3 install gdal
           pip3 install rasterio==1.2.10
           # apt install git python3-venv -y

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
+          # noninteractive is necessary to install libgdal-dev
+          # which is needed for python gdal which is
+          # required by rasterio
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update && sudo apt-get install python3 python3-pip python3-venv libgdal-dev -y
           pip3 install build

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update && sudo apt-get install libgdal-dev -y
+          sudo apt-get update && sudo apt-get install python3-pip libgdal-dev -y
           pip3 install build
       - name: Build package
         run: python3 -m build --outdir build .

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,9 @@ name: Upload Python Package
 # on:
 #   release:
 #     types: [published]
+on:
+  push:
+    branches: [wheel]
 
 jobs:
   deploy:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,10 +27,8 @@ jobs:
       #     python-version: '3.x'
       - name: Install dependencies
         run: |
-          # sudo apt-get update && sudo apt-get install python3 python3-pip python3-venv libgdal-dev -y
-          cat /etc/*-release
-          apk update && apk add python3 python3-pip python3-venv libgdal-dev -y
-          pip3 install gdal
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update && sudo apt-get install python3 python3-pip python3-venv libgdal-dev -y
           pip3 install rasterio==1.2.10
           # apt install git python3-venv -y
           # export SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,13 +21,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
+      # - name: Set up Python
+      #   uses: actions/setup-python@v2
+      #   with:
+      #     python-version: '3.x'
       - name: Install dependencies
         run: |
-          apt update && apt install python3 python3-pip libgdal-dev -y
+          apt update && apt install python3 python3-pip python3-venv libgdal-dev -y
           pip3 install gdal
           pip3 install rasterio==1.2.10
           # apt install git python3-venv -y

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: |
           apt update && apt install python3 python3-pip -y
+          pip3 install rasterio==1.2.10
+          # apt install git python3-venv -y
+          # export SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
           # pip3 install --upgrade pip
           pip3 install build
       - name: Build package

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,8 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          apt update && apt install python3 python3-pip libgdal-dev -y
+          apt update && apt install python3 python3-pip -y
+          pip3 install gdal
           pip3 install rasterio==1.2.10
           # apt install git python3-venv -y
           # export SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update && sudo apt-get install python3-pip libgdal-dev -y
+          sudo apt-get update && sudo apt-get install python3 python3-pip libgdal-dev -y
           pip3 install build
       - name: Build package
         run: python3 -m build --outdir build .

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update && sudo apt-get install python3 python3-pip libgdal-dev -y
+          pip3 install rasterio==1.2.10
           pip3 install build
       - name: Build package
         run: python3 -m build --outdir build .

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,18 +21,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      # - name: Set up Python
-      #   uses: actions/setup-python@v2
-      #   with:
-      #     python-version: '3.x'
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
       - name: Install dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update && sudo apt-get install python3 python3-pip python3-venv libgdal-dev -y
-          pip3 install rasterio==1.2.10
-          # apt install git python3-venv -y
-          # export SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
-          # pip3 install --upgrade pip
+          sudo apt-get update && sudo apt-get install libgdal-dev -y
           pip3 install build
       - name: Build package
         run: python3 -m build --outdir build .

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,14 +8,14 @@
 
 name: Upload Python Package
 
-on:
-  release:
-    types: [published]
+# on:
+#   release:
+#     types: [published]
 
 jobs:
   deploy:
 
-    runs-on: ubuntu-latest
+    runs-on: mundialis/actinia-core:alpine-runtime-pkgs_v7
 
     steps:
       - uses: actions/checkout@v2
@@ -25,8 +25,8 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install build
+          pip3 install --upgrade pip
+          pip3 install build
       - name: Build package
         run: python3 -m build --outdir build .
       - name: Release

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: ubuntu-latest
+    runs-on: alpine-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -27,7 +27,8 @@ jobs:
       #     python-version: '3.x'
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install python3 python3-pip python3-venv libgdal-dev -y
+          # sudo apt-get update && sudo apt-get install python3 python3-pip python3-venv libgdal-dev -y
+          apk update && apk add python3 python3-pip python3-venv libgdal-dev -y
           pip3 install gdal
           pip3 install rasterio==1.2.10
           # apt install git python3-venv -y

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: mundialis/actinia-core:alpine-runtime-pkgs_v7
+    runs-on: ubuntu:latest
 
     steps:
       - uses: actions/checkout@v2
@@ -27,7 +27,8 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          pip3 install --upgrade pip
+          apt update && apt install python3 python3-pip -y
+          # pip3 install --upgrade pip
           pip3 install build
       - name: Build package
         run: python3 -m build --outdir build .

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          apt update && apt install python3 python3-pip -y
+          apt update && apt install python3 python3-pip libgdal-dev -y
           pip3 install rasterio==1.2.10
           # apt install git python3-venv -y
           # export SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,9 +8,9 @@
 
 name: Upload Python Package
 
-# on:
-#   release:
-#     types: [published]
+on:
+  release:
+    types: [published]
 on:
   push:
     branches: [wheel]

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ jobs:
       #     python-version: '3.x'
       - name: Install dependencies
         run: |
-          sudo apt-get update && apt-get install python3 python3-pip python3-venv libgdal-dev -y
+          sudo apt-get update && sudo apt-get install python3 python3-pip python3-venv libgdal-dev -y
           pip3 install gdal
           pip3 install rasterio==1.2.10
           # apt install git python3-venv -y


### PR DESCRIPTION
From release 3.3.0, the build of the wheel in the github action fails due to rasterio dependencies, see [action for 3.3.0](https://github.com/mundialis/actinia_core/runs/5772793800?check_suite_focus=true) and[ action for 4.0.0](https://github.com/mundialis/actinia_core/runs/5787156855?check_suite_focus=true). This PR fixes it (still testing).