### PR TITLE
Add more modules and configuration to add additinal modules in config

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -92,7 +92,7 @@ To lint your local changes, run
 
 Inside the container, you can run GRASS GIS with:
 ```
-# Download GRASS GIS test data and put it into a directory
+# Download GRASS GIS test data and put it into a directory (nc_spm_08_grass7 works also for GRASS GIS 8)
 cd /actinia_core/grassdb
 wget https://grass.osgeo.org/sampledata/north_carolina/nc_spm_08_grass7.tar.gz && \
      tar xzvf nc_spm_08_grass7.tar.gz && \

--- a/docker/actinia-core-alpine/Dockerfile
+++ b/docker/actinia-core-alpine/Dockerfile
@@ -29,11 +29,16 @@ USER root
 COPY --from=grass /usr/local/bin/grass /usr/local/bin/grass
 COPY --from=grass /usr/local/grass* /usr/local/grass/
 RUN pip3 install --upgrade pip six grass-session --ignore-installed six
-RUN ln -s /usr/local/grass /usr/local/grass7
+RUN ln -s /usr/local/grass /usr/local/grass8
 RUN ln -s /usr/local/grass `grass --config path`
 RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python3 --version
+
+# install GRASS GIS addon d.rast.multi, because it is needed for STRDS render
+# endpoint
+RUN grass --tmp-location EPSG:4326 --exec g.extension -s \
+  extension=d.rast.multi url=https://github.com/mundialis/d_rast_multi
 
 # actinia-core and actinia libs BUILD
 WORKDIR /build

--- a/docker/actinia-core-alpine/actinia.cfg
+++ b/docker/actinia-core-alpine/actinia.cfg
@@ -3,9 +3,9 @@ grass_database = /actinia_core/grassdb
 grass_user_database = /actinia_core/userdata
 grass_tmp_database = /actinia_core/workspace/temp_db
 grass_resource_dir = /actinia_core/resources
-grass_gis_base = /usr/local/grass7
+grass_gis_base = /usr/local/grass80
 grass_gis_start_script = /usr/local/bin/grass
-grass_addon_path = /root/.grass7/addons/
+grass_addon_path = /root/.grass8/addons/
 
 [API]
 plugins = []

--- a/docker/actinia-core-dev/Dockerfile
+++ b/docker/actinia-core-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM mundialis/actinia-core:g79-latest-alpine
+FROM mundialis/actinia-core:latest
 
 # # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/docker/actinia-core-dev/actinia.cfg
+++ b/docker/actinia-core-dev/actinia.cfg
@@ -3,9 +3,9 @@ grass_database = /actinia_core/grassdb
 grass_user_database = /actinia_core/userdata
 grass_tmp_database = /actinia_core/workspace/temp_db
 grass_resource_dir = /actinia_core/resources
-grass_gis_base = /usr/local/grass7
+grass_gis_base = /usr/local/grass80
 grass_gis_start_script = /usr/local/bin/grass
-grass_addon_path = /root/.grass7/addons/
+grass_addon_path = /root/.grass8/addons/
 
 [API]
 plugins = []

--- a/docker/actinia-core-dev/actinia.cfg
+++ b/docker/actinia-core-dev/actinia.cfg
@@ -6,6 +6,7 @@ grass_resource_dir = /actinia_core/resources
 grass_gis_base = /usr/local/grass80
 grass_gis_start_script = /usr/local/bin/grass
 grass_addon_path = /root/.grass8/addons/
+additional_allowed_modules=i.albedo
 
 [API]
 plugins = []

--- a/docker/actinia-core-tests/Dockerfile
+++ b/docker/actinia-core-tests/Dockerfile
@@ -34,6 +34,8 @@ RUN pip3 install actinia-api@https://github.com/mundialis/actinia-api/releases/d
 
 # install GRASS addons required for tests
 RUN grass --tmp-location EPSG:4326 --exec g.extension -s extension=r.colors.out_sld
+RUN grass --tmp-location EPSG:4326 --exec g.extension -s \
+  extension=d.rast.multi url=https://github.com/mundialis/d_rast_multi
 
 # copy needed files and configs for test
 COPY docker/actinia-core-alpine/actinia.cfg /etc/default/actinia

--- a/docker/actinia-core-tests/Dockerfile
+++ b/docker/actinia-core-tests/Dockerfile
@@ -29,7 +29,11 @@ RUN wget --quiet https://grass.osgeo.org/sampledata/north_carolina/nc_spm_mapset
   mv  modis_lst /actinia_core/grassdb/nc_spm_08/modis_lst
 RUN chown -R 1001:1001 /actinia_core/grassdb/nc_spm_08/modis_lst && chmod -R g+w /actinia_core/grassdb/nc_spm_08/modis_lst
 
+# install actinia-api
 RUN pip3 install actinia-api@https://github.com/mundialis/actinia-api/releases/download/${ACTINIA_API_VERSION}/actinia_api-${ACTINIA_API_VERSION}-py3-none-any.whl
+
+# install GRASS addons required for tests
+RUN grass --tmp-location EPSG:4326 --exec g.extension -s extension=r.colors.out_sld
 
 # copy needed files and configs for test
 COPY docker/actinia-core-alpine/actinia.cfg /etc/default/actinia

--- a/docker/actinia-core-tests/Dockerfile
+++ b/docker/actinia-core-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mundialis/actinia-core:2.0.0 as actinia_test
+FROM mundialis/actinia-core:4.0.0 as actinia_test
 
 LABEL authors="Carmen Tawalika,Anika Weinmann"
 LABEL maintainer="tawalika@mundialis.de,weinmann@mundialis.de"

--- a/docker/actinia-core-tests/actinia-test.cfg
+++ b/docker/actinia-core-tests/actinia-test.cfg
@@ -4,9 +4,9 @@ grass_database = /actinia_core/grassdb
 grass_user_database = /actinia_core/userdata
 grass_tmp_database = /actinia_core/workspace/temp_db
 grass_resource_dir = /actinia_core/resources
-grass_addon_path = /root/.grass7/addons/
-grass_gis_base = /usr/local/grass7
-grass_modules_xml_path = /usr/local/grass7/gui/wxpython/xml/module_items.xml
+grass_addon_path = /root/.grass8/addons/
+grass_gis_base = /usr/local/grass80
+grass_modules_xml_path = /usr/local/grass80/gui/wxpython/xml/module_items.xml
 grass_default_location = nc_spm_08
 
 [API]

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -90,6 +90,7 @@ allow_list = [
 #           t.rast.udf)
 # * t.rast.sample (https://github.com/mundialis/t.rast.sample)
 
+
 class Configuration(object):
 
     def __init__(self):

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -41,40 +41,54 @@ else:
 if not os.path.isfile(DEFAULT_CONFIG_PATH):
     open(DEFAULT_CONFIG_PATH, 'a').close()
 
-# Generate from GRASS_module_white_list.txt
-white_list = [
-    'r.blend', 'r.buffer', 'r.buffer.lowmem', 'r.carve', 'r.category', 'r.circle',
-    'r.clump', 'r.coin', 'r.colors', 'r.composite', 'r.compress', 'r.contour',
-    'r.cost', 'r.covar', 'r.cross', 'r.describe', 'r.distance', 'r.drain',
-    'r.fill.dir', 'r.fillnulls', 'r.flow', 'r.grow', 'r.grow.distance', 'r.gwflow',
-    'r.his', 'r.horizon', 'r.kappa', 'r.lake', 'r.latlong', 'r.li.cwed',
-    'r.li.dominance', 'r.li.edgedensity', 'r.li.mpa', 'r.li.mps', 'r.li.padcv',
-    'r.li.padrange', 'r.li.padsd', 'r.li.patchdensity', 'r.li.patchnum',
-    'r.li.pielou', 'r.li.renyi', 'r.li.richness', 'r.li.shannon', 'r.li.shape',
-    'r.li.simpson', 'r.mapcalc', 'r.mask', 'r.mfilter', 'r.mode', 'r.neighbors',
-    'r.null', 'r.param.scale', 'r.patch', 'r.plane', 'r.profile', 'r.proj',
-    'r.quant', 'r.quantile', 'r.random', 'r.random.cells', 'r.random.surface',
-    'r.reclass', 'r.reclass.area', 'r.recode', 'r.region', 'r.regression.line',
+allow_list = [
+    'd.legend', 'd.rast', 'd.rast.multi', 'd.vect', 'exporter', 'g.findfile',
+    'g.gisenv', 'g.list', 'g.mapset', 'g.proj', 'g.region', 'g.remove',
+    'g.rename', 'g.version', 'i.atcorr', 'i.cluster', 'i.colors.enhance',
+    'i.gensig', 'i.group', 'i.landsat.toar', 'i.maxlik', 'i.pansharpen',
+    'i.segment', 'i.tasscap', 'i.vi', 'importer', 'r.blend', 'r.buffer',
+    'r.buffer.lowmem', 'r.carve', 'r.category', 'r.circle', 'r.clump',
+    'r.coin', 'r.colors', 'r.colors.out', 'r.composite', 'r.compress',
+    'r.contour', 'r.cost', 'r.covar', 'r.cross', 'r.describe', 'r.distance',
+    'r.drain', 'r.fill.dir', 'r.fillnulls', 'r.flow', 'r.grow',
+    'r.grow.distance', 'r.gwflow', 'r.his', 'r.horizon', 'r.info', 'r.kappa',
+    'r.lake', 'r.latlong', 'r.li.cwed', 'r.li.dominance', 'r.li.edgedensity',
+    'r.li.mpa', 'r.li.mps', 'r.li.padcv', 'r.li.padrange', 'r.li.padsd',
+    'r.li.patchdensity', 'r.li.patchnum', 'r.li.pielou', 'r.li.renyi',
+    'r.li.richness', 'r.li.shannon', 'r.li.shape', 'r.li.simpson', 'r.mapcalc',
+    'r.mask', 'r.mfilter', 'r.mode', 'r.neighbors', 'r.null', 'r.out.png',
+    'r.param.scale', 'r.patch', 'r.plane', 'r.profile', 'r.proj', 'r.quant',
+    'r.quantile', 'r.random', 'r.random.cells', 'r.random.surface', 'r.reclass',
+    'r.reclass.area', 'r.recode', 'r.region', 'r.regression.line',
     'r.regression.multi', 'r.regression.series', 'r.relief', 'r.report',
-    'r.resamp.bspline', 'r.resamp.filter', 'r.resamp.interp', 'r.resample',
-    'r.resamp.rst', 'r.resamp.stats', 'r.rescale', 'r.rescale.eq', 'r.rgb', 'r.ros',
-    'r.series', 'r.series.accumulate', 'r.series.interp', 'r.shade',
+    'r.resamp.bspline', 'r.resamp.filter', 'r.resamp.interp', 'r.resamp.rst',
+    'r.resamp.stats', 'r.resample', 'r.rescale', 'r.rescale.eq', 'r.rgb',
+    'r.ros', 'r.series', 'r.series.accumulate', 'r.series.interp', 'r.shade',
     'r.sim.sediment', 'r.sim.water', 'r.slope.aspect', 'r.solute.transport',
     'r.spread', 'r.spreadpath', 'r.statistics', 'r.stats', 'r.stats.quantile',
     'r.stats.zonal', 'r.stream.extract', 'r.sun', 'r.sunhours', 'r.sunmask',
     'r.support', 'r.support.stats', 'r.surf.area', 'r.surf.contour',
-    'r.surf.fractal', 'r.surf.gauss', 'r.surf.idw', 'r.surf.random', 'r.terraflow',
-    'r.texture', 'r.thin', 'r.tile', 'r.tileset', 'r.timestamp', 'r.topidx',
-    'r.topmodel', 'r.to.rast3', 'r.to.rast3elev', 'r.to.vect', 'r.transect',
-    'r.univar', 'r.uslek', 'r.usler', 'r.viewshed', 'r.vol.dem', 'r.volume',
-    'r.walk', 'r.water.outlet', 'r.watershed', 'r.what', 'r.what.color', 'r.info',
-    'g.region', 'g.mapset', 'g.proj', 'g.remove', 'g.rename', 'g.version',
-    'g.list', 'g.findfile', 'g.gisenv', 'i.vi', 'v.in.ascii', 'v.random',
-    't.rast.sample', 'r.out.png', 'r.colors.out', 'd.rast', 'd.vect', 'd.legend',
-    't.rast.aggr_func', 'd.rast.multi', 'v.buffer', 't.rast.extract',
-    't.rast.mapcalc', 't.rast.series', 't.rast.colors', 't.info', 't.rast.list',
-    't.rast.univar', 'importer', 'exporter']
-
+    'r.surf.fractal', 'r.surf.gauss', 'r.surf.idw', 'r.surf.random',
+    'r.terraflow', 'r.texture', 'r.thin', 'r.tile', 'r.tileset', 'r.timestamp',
+    'r.to.rast3', 'r.to.rast3elev', 'r.to.vect', 'r.topidx', 'r.topmodel',
+    'r.transect', 'r.univar', 'r.uslek', 'r.usler', 'r.viewshed', 'r.vol.dem',
+    'r.volume', 'r.walk', 'r.water.outlet', 'r.watershed', 'r.what',
+    'r.what.color', 't.create', 't.info', 't.list', 't.rast.accdetect',
+    't.rast.accumulate', 't.rast.aggr_func', 't.rast.aggregate',
+    't.rast.aggregate.ds', 't.rast.algebra', 't.rast.colors', 't.rast.extract',
+    't.rast.gapfill', 't.rast.list', 't.rast.mapcalc', 't.rast.sample',
+    't.rast.series', 't.rast.univar', 't.rast.what', 't.register', 't.remove',
+    't.unregister', 'v.buffer', 'v.clean', 'v.db.select', 'v.db.univar',
+    'v.db.update', 'v.dissolve', 'v.in.ascii', 'v.overlay', 'v.patch',
+    'v.random', 'v.rast.stats', 'v.select', 'v.what.rast', 'v.what.strds'
+]
+# GRASS ADDON: maybe not installed:
+# * r.regression.series
+# * r.vol.dem
+# * d.rast.multi (https://github.com/mundialis/d_rast_multi)
+# * t.rast.aggr_func (https://github.com/mundialis/openeo-addons/tree/master/
+#           t.rast.udf)
+# * t.rast.sample (https://github.com/mundialis/t.rast.sample)
 
 class Configuration(object):
 
@@ -110,6 +124,9 @@ class Configuration(object):
             self.GRASS_GIS_BASE, "gui", "wxpython", "xml", "module_items.xml")
         # The path to the activation script of the python2 venv (old)
         self.GRASS_VENV = "%s/src/actinia/grass_venv/bin/activate_this.py" % home
+        # ADDITIONAL_ALLOWED_MODULES: modules to extend MODULE_ALLOW_LIST
+        # e.g. ['i.cutlines', 'r.learn.ml2']
+        self.ADDITIONAL_ALLOWED_MODULES = []
 
         """
         LIMITS
@@ -213,7 +230,7 @@ class Configuration(object):
         self.DEFAULT_USER_GROUP = "group"
 
         # Not in config file
-        self.MODULE_WHITE_LIST = white_list  # The default white list of GRASS modules
+        self.MODULE_ALLOW_LIST = allow_list  # The default allow list of GRASS modules
 
         # AWS S3 ADMIN CREDENTIALS
         self.S3_AWS_ACCESS_KEY_ID = ""
@@ -382,6 +399,13 @@ class Configuration(object):
                         "GRASS", "GRASS_MODULES_XML_PATH")
                 if config.has_option("GRASS", "GRASS_VENV"):
                     self.GRASS_VENV = config.get("GRASS", "GRASS_VENV")
+                if config.has_option("MANAGEMENT", "ADDITIONAL_ALLOWED_MODULES"):
+                    self.ADDITIONAL_ALLOWED_MODULES = \
+                        ast.literal_eval(config.get(
+                            "MANAGEMENT", "ADDITIONAL_ALLOWED_MODULES"))
+                    self.MODULE_ALLOW_LIST.extend(
+                        self.ADDITIONAL_ALLOWED_MODULES)
+                    self.MODULE_ALLOW_LIST = list(set(self.MODULE_ALLOW_LIST))
 
             if config.has_section("LIMITS"):
                 if config.has_option("LIMITS", "MAX_CELL_LIMIT"):

--- a/src/actinia_core/core/common/user.py
+++ b/src/actinia_core/core/common/user.py
@@ -70,7 +70,7 @@ class ActiniaUser(object):
                                                     "landsat"],
                                       "ECAD": ["PERMANENT"],
                                       "latlong_wgs84": ["PERMANENT"]},
-                 accessible_modules=global_config.MODULE_WHITE_LIST,
+                 accessible_modules=global_config.MODULE_ALLOW_LIST,
                  cell_limit=global_config.MAX_CELL_LIMIT,
                  process_num_limit=global_config.PROCESS_NUM_LIMIT,
                  process_time_limit=global_config.PROCESS_TIME_LIMT):
@@ -658,7 +658,7 @@ class ActiniaUser(object):
                                                        "landsat"],
                                          "ECAD": ["PERMANENT"],
                                          "latlong_wgs84": ["PERMANENT"]},
-                    accessible_modules=global_config.MODULE_WHITE_LIST,
+                    accessible_modules=global_config.MODULE_ALLOW_LIST,
                     cell_limit=global_config.MAX_CELL_LIMIT,
                     process_num_limit=global_config.PROCESS_NUM_LIMIT,
                     process_time_limit=global_config.PROCESS_TIME_LIMT):

--- a/src/actinia_core/core/list_grass_modules.py
+++ b/src/actinia_core/core/list_grass_modules.py
@@ -87,7 +87,7 @@ class GrassModuleReader(object):
                 keywords = self.xml.readElementText()
 
         if module and keywords and description:
-            if module in global_config.MODULE_WHITE_LIST:
+            if module in global_config.MODULE_ALLOW_LIST:
                 # First and second keyword must exist
                 key_list = str(keywords).split(",")
                 first_key = key_list[0]

--- a/src/actinia_core/processing/actinia_processing/persistent/strds_management.py
+++ b/src/actinia_core/processing/actinia_processing/persistent/strds_management.py
@@ -147,7 +147,7 @@ class PersistentSTRDSDeleter(PersistentProcessing):
         pc = {"1": {"module": "t.remove",
                     "inputs": {"type": "strds",
                                "inputs": self.map_name},
-                    "flags": ""}}
+                    "flags": "f"}}
 
         if args and "recursive" in args and args["recursive"] is True:
             pc["1"]["flags"] = "rf"

--- a/tests/test_common_base.py
+++ b/tests/test_common_base.py
@@ -64,8 +64,8 @@ def setup_environment():
     # GRASS
 
     # Setup the test environment
-    global_config.GRASS_GIS_BASE = "/usr/local/grass78/"
-    global_config.GRASS_GIS_START_SCRIPT = "/usr/local/bin/grass78"
+    global_config.GRASS_GIS_BASE = "/usr/local/grass80/"
+    global_config.GRASS_GIS_START_SCRIPT = "/usr/local/bin/grass80"
     # global_config.GRASS_DATABASE= "/usr/local/grass_test_db"
     # global_config.GRASS_DATABASE = "%s/actinia/grass_test_db" % home
 

--- a/tests/test_resource_base.py
+++ b/tests/test_resource_base.py
@@ -78,8 +78,8 @@ def setup_environment():
 
     # GRASS GIS
     # Setup the test environment
-    global_config.GRASS_GIS_BASE = "/usr/local/grass78/"
-    global_config.GRASS_GIS_START_SCRIPT = "/usr/local/bin/grass78"
+    global_config.GRASS_GIS_BASE = "/usr/local/grass80/"
+    global_config.GRASS_GIS_START_SCRIPT = "/usr/local/bin/grass80"
     # global_config.GRASS_DATABASE= "/usr/local/grass_test_db"
     # global_config.GRASS_DATABASE = "%s/actinia/grass_test_db" % home
     global_config.GRASS_TMP_DATABASE = "/tmp"


### PR DESCRIPTION
- Add more modules to https://github.com/mundialis/actinia_core/issues/271.
- rename white list to allow list
- add configurable additinal modules via `+additional_allowed_modules` in `GRASS` section in actinia.cfg file

- update dev Dockerfile to latest actinia image (with GRASS8)