### PR TITLE
allow character "&" for t.rast.bandcalc

### DIFF
--- a/src/actinia_core/core/common/process_chain.py
+++ b/src/actinia_core/core/common/process_chain.py
@@ -554,7 +554,8 @@ class ProcessChainConverter(object):
         # Check for un-allowed characters in the parameter list
         for entry in params:
             if "&" in entry and \
-               module_name not in ("r.mapcalc", "t.rast.mapcalc", "t.rast.algebra", "t.rast.bandcalc"):
+               module_name not in ("r.mapcalc", "t.rast.mapcalc",
+                                   "t.rast.algebra", "t.rast.bandcalc"):
                 raise AsyncProcessError("Character '&' not allowed in "
                                         "parameters for %s" % module_name)
 

--- a/src/actinia_core/core/common/process_chain.py
+++ b/src/actinia_core/core/common/process_chain.py
@@ -554,7 +554,7 @@ class ProcessChainConverter(object):
         # Check for un-allowed characters in the parameter list
         for entry in params:
             if "&" in entry and \
-               module_name not in ("r.mapcalc", "t.rast.mapcalc", "t.rast.algebra"):
+               module_name not in ("r.mapcalc", "t.rast.mapcalc", "t.rast.algebra", "t.rast.bandcalc"):
                 raise AsyncProcessError("Character '&' not allowed in "
                                         "parameters for %s" % module_name)
 


### PR DESCRIPTION
`t.rast.bandcalc` must be able to pass mapcalc expressions including "&" to `t.rast.mapcalc`