### PR TITLE
Fix dev setup

### DIFF
--- a/docker/actinia-core-dev/Dockerfile
+++ b/docker/actinia-core-dev/Dockerfile
@@ -15,5 +15,7 @@ RUN pip3 uninstall actinia_core -y
 COPY docker/actinia-core-dev/actinia.cfg /etc/default/actinia
 COPY . /src/actinia_core/
 
+RUN git config --global --add safe.directory /src/actinia*
+
 WORKDIR /src/actinia_core/
 RUN pip3 install -e .


### PR DESCRIPTION
In a newer version of git, some security vulnerabilities were fixed. The new version adresses [CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/), where git won't allow commands when the ownership of the folder doesn't match. In plain docker evironment this is not a problem but as for the dev setup, the source code is mounted, this leads to an issue. This PR solves this.