### PR TITLE
Enable separate redis queue per job

### DIFF
--- a/redis_queue.md
+++ b/redis_queue.md
@@ -7,7 +7,7 @@
 redis_queue_server_url = redis-queue
 redis_queue_server_password = pass
 worker_prefix = job_queue
-queue_type = perjob
+queue_type = per_job
 ```
 or
 ```

--- a/redis_queue.md
+++ b/redis_queue.md
@@ -1,0 +1,164 @@
+# Redis Queue for Jobs
+
+## Dev setup
+- adjust config, e.g.
+```
+[QUEUE]
+redis_queue_server_url = redis-queue
+redis_queue_server_password = pass
+worker_prefix = job_queue
+queue_type = perjob
+```
+or
+```
+[QUEUE]
+number_of_workers = 1
+queue_type = redis
+```
+
+- Startup actinia with above config in preferred way, e.g.
+`cd ~/repos/actinia` + press F5
+- Start Container for worker
+```
+docker-compose -f actinia-docker/docker-compose-dev-rq.yml run --rm --service-ports --entrypoint sh actinia-worker
+```
+- inside container, start worker listening to specified queue
+```
+QUEUE_NAME=job_queue_0
+rq_custom_worker $QUEUE_NAME -c /etc/default/actinia
+```
+
+
+## Redis Details
+
+```
+127.0.0.1:6379> KEYS *
+3) "actinia_worker_count"
+9) "rq:workers"
+7) "rq:workers:job_queue_0"
+4) "rq:worker:04e384aad9e743ffb2fb021cfaad421a"
+9) "rq:job:b6de9170-0fa6-4118-8eb7-9d5f43a37c23"
+1) "rq:queues"
+5) "rq:queue:job_queue_0"
+6) "rq:clean_registries:job_queue_0"
+5) "rq:failed:job_queue_0"
+1) "rq:finished:job_queue_0"
+```
+### actinia_worker_count
+- only in redis_interface for current queue
+- created at first HTTP POST request
+- currently outcommented
+
+### workers
+- exists if at least one worker is active, else deleted.
+```r
+127.0.0.1:6379> TYPE rq:workers
+set
+127.0.0.1:6379> SMEMBERS rq:workers
+1) "rq:worker:afb2961308964653abd2328893a1cd95"
+
+127.0.0.1:6379> TYPE rq:workers:job_queue_0
+set
+127.0.0.1:6379> SMEMBERS rq:workers:job_queue_0
+1) "rq:worker:afb2961308964653abd2328893a1cd95"
+
+127.0.0.1:6379> TYPE rq:worker:afb2961308964653abd2328893a1cd95
+hash
+127.0.0.1:6379> HGETALL rq:worker:afb2961308964653abd2328893a1cd95
+ 1) "birth"
+ 2) "2022-01-21T13:05:32.355053Z"
+ 3) "last_heartbeat"
+ 4) "2022-01-21T13:06:04.545367Z"
+ 5) "queues"
+ 6) "job_queue_0"
+ 7) "pid"
+ 8) "162"
+ 9) "hostname"
+10) "4c897b45a129"
+11) "version"
+12) "1.7.0"
+13) "python_version"
+14) "3.8.5 (default, Jul 20 2020, 23:11:29) \n[GCC 9.3.0]"
+15) "state"
+16) "idle"
+17) "successful_job_count"
+18) "1"
+19) "total_working_time"
+20) "6.920567"
+...
+15) "state"
+16) "busy"
+17) "current_job"
+18) "626832ff-7998-4276-b0d9-e4fa98b6a69d"
+```
+
+### job
+- created on job start. Then job is "accepted"
+- also for synchronous requests, e.g. GET mapsets, tpl processing, ...
+- deleted after a while - TODO check when?
+```r
+127.0.0.1:6379> TYPE rq:job:b6de9170-0fa6-4118-8eb7-9d5f43a37c23
+hash
+127.0.0.1:6379> HGETALL rq:job:b6de9170-0fa6-4118-8eb7-9d5f43a37c23
+ 1) "status"
+ 2) "finished"
+ 3) "created_at"
+ 4) "2022-01-21T13:36:21.700405Z"
+ 5) "enqueued_at"
+ 6) "2022-01-21T13:36:21.700609Z"
+ 7) "data"
+ 8) "x\x9c\xed\x1a\xcbn\x1c\xc7\x91\xb2\xf9\x14\x1f\x1c......."
+ 9) "description"
+10) "actinia_core.rest.ephemeral_processing_with_export.start_job(<actinia_core.core.resource_data_container.ResourceDataContainer object at ...)"
+11) "timeout"
+12) "180"
+13) "last_heartbeat"
+14) "2022-01-21T13:37:39.900333Z"
+15) "worker_name"
+16) ""
+17) "ended_at"
+18) "2022-01-21T13:37:48.727823Z"
+19) "started_at"
+20) "2022-01-21T13:37:40.929638Z"
+21) "origin"
+22) "job_queue_0"
+```
+
+### queues
+- rq:queue:job_queue_0 only exists if job in queue
+- as soon as worker takes job, queue is removed
+- => if no job is left in queue, it is removed
+```r
+127.0.0.1:6379> TYPE rq:queues
+set
+127.0.0.1:6379> SMEMBERS rq:queues
+1) "rq:queue:job_queue_0"
+
+127.0.0.1:6379> TYPE rq:queue:job_queue_0
+list
+127.0.0.1:6379> LRANGE rq:queue:job_queue_0 0 -1
+1) "b6d8672b-2afc-4740-80d1-46345a28abdf"
+
+127.0.0.1:6379> TYPE rq:failed:job_queue_0
+zset
+127.0.0.1:6379> ZRANGE rq:failed:job_queue_0 0 -1 WITHSCORES
+1) "8b8d4e6a-34ef-4da2-9f86-70b1034664ab"
+2) "1674302827"
+3) "e27045ef-bdf4-440c-a808-d4e748dfab2f"
+4) "1674302827"
+5) "dfa4d4fa-39bf-4021-94af-f3d1763dc789"
+6) "1674302869"
+
+127.0.0.1:6379> ZRANGE rq:finished:job_queue_0 0 -1 WITHSCORES
+1) "b6de9170-0fa6-4118-8eb7-9d5f43a37c23"
+2) "1642772768"
+
+```
+
+### misc
+```r
+127.0.0.1:6379> TYPE rq:clean_registries:job_queue_0
+string
+127.0.0.1:6379> GET rq:clean_registries:job_queue_0
+"1"
+```

--- a/scripts/rq_starter
+++ b/scripts/rq_starter
@@ -59,7 +59,7 @@ def create_workers(config_file):
     global worker_pids
 
     for i in range(conf.NUMBER_OF_WORKERS):
-        name = "%s_%i"%(conf.WORKER_QUEUE_NAME, i)
+        name = "%s_%i"%(conf.WORKER_QUEUE_PREFIX, i)
         print("Start worker queue", name)
         args = ["rq_custom_worker", name]
         proc = subprocess.Popen(args)

--- a/src/actinia_core/README.md
+++ b/src/actinia_core/README.md
@@ -19,7 +19,6 @@ Some other modules outside of core folder are concerned as well.
 | module | import|
 | - | - |
 | actinia_core.endpoints | create_endpoints |
-| actinia_core.health_check | health_check |
 | actinia_core.core.common.api_logger | log_api_call |
 | actinia_core.core.common.app | auth, flask_api, flask_app |
 | actinia_core.core.common.aws_sentinel_interface | AWSSentinel2AInterface |
@@ -31,7 +30,7 @@ Some other modules outside of core folder are concerned as well.
 | actinia_core.core.common.process_object | Process |
 | actinia_core.core.common.process_queue | create_process_queue |
 | actinia_core.core.common.redis_base | RedisBaseInterface |
-| actinia_core.core.common.redis_interface | connect, disconnect, create_job_queues, enqueue_job |
+| actinia_core.core.common.redis_interface | connect, disconnect, enqueue_job |
 | actinia_core.core.common.response_models | create_response_from_model, ProcessingErrorResponseModel, ProcessingResponseModel, SimpleResponseModel, StringListProcessingResultResponseModel, UnivarResultModel |
 | actinia_core.core.common.sentinel_processing_library | Sentinel2Processing |
 | actinia_core.core.common.user | ActiniaUser |
@@ -48,7 +47,6 @@ Some other modules outside of core folder are concerned as well.
 | actinia_core.rest.ephemeral_processing_with_export | SCHEMA_DOC |
 | actinia_core.rest.persistent_processing | SCHEMA_DOC |
 | actinia_core.testsuite | ActiniaTestCaseBase, URL_PREFIX |
-| actinia_core.version | version |
 
 
 URL_PREFIX moved to actinia_api
@@ -101,8 +99,6 @@ actinia_core.core.common.response_models import ProcessingErrorResponseModel
 
 __satellite__
 ```
-actinia_core.health_check import health_check
-actinia_core.version import version
 actinia_core.processing.actinia_processing.ephemeral.ephemeral_processing_with_export import EphemeralProcessingWithExport
 actinia_core.rest.persistent_processing import PersistentProcessing
 actinia_core.core.common.aws_sentinel_interface import AWSSentinel2AInterface
@@ -111,7 +107,7 @@ actinia_core.core.common.google_satellite_bigquery_interface import GoogleSatell
 actinia_core.core.common.landsat_processing_library import LandsatProcessing, SCENE_BANDS, extract_sensor_id_from_scene_id, RASTER_SUFFIXES
 actinia_core.core.common.process_object import Process
 actinia_core.core.common.process_queue import create_process_queue
-actinia_core.core.common.redis_interface import connect, create_job_queues
+actinia_core.core.common.redis_interface import connect
 actinia_core.core.common.response_models import SimpleResponseModel
 actinia_core.core.common.response_models import UnivarResultModel
 actinia_core.core.common.sentinel_processing_library import Sentinel2Processing

--- a/src/actinia_core/README.md
+++ b/src/actinia_core/README.md
@@ -31,7 +31,7 @@ Some other modules outside of core folder are concerned as well.
 | actinia_core.core.common.process_object | Process |
 | actinia_core.core.common.process_queue | create_process_queue |
 | actinia_core.core.common.redis_base | RedisBaseInterface |
-| actinia_core.core.common.redis_interface | full import! TODO check what is used. Else: connect, create_job_queues, enqueue_job |
+| actinia_core.core.common.redis_interface | connect, disconnect, create_job_queues, enqueue_job |
 | actinia_core.core.common.response_models | create_response_from_model, ProcessingErrorResponseModel, ProcessingResponseModel, SimpleResponseModel, StringListProcessingResultResponseModel, UnivarResultModel |
 | actinia_core.core.common.sentinel_processing_library | Sentinel2Processing |
 | actinia_core.core.common.user | ActiniaUser |
@@ -82,7 +82,7 @@ actinia_core.core.common.config import Configuration
 actinia_core.core.common.process_chain import GrassModule
 /# from actinia_core.core.common.process_queue import create_process_queue
 actinia_core.core.common.redis_base import RedisBaseInterface
-actinia_core.core.common import redis_interface
+actinia_core.core.common.redis_interface import enqueue_job, connect, disconnect
 actinia_core.core.common.response_models import create_response_from_model
 actinia_core.core.common.response_models import StringListProcessingResultResponseModel
 actinia_core.core.common.user import ActiniaUser

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -182,10 +182,45 @@ class Configuration(object):
         # The base name of the redis worker queue, it will be extended by a
         # numerical suffix that represents the worker id/number database to
         # re-queue it, usually this is not necessary
-        self.WORKER_QUEUE_NAME = "job_queue"
+        self.WORKER_QUEUE_PREFIX = "job_queue"
         # The base name of the redis worker queue logfile, it will be extended
         # by a numerical suffix that represents the worker id/number
         self.WORKER_LOGFILE = "%s/actinia/workspace/tmp/worker.log" % home
+
+        """
+        QUEUE
+        """
+        # The number of queues that process jobs
+        self.NUMBER_OF_WORKERS = 3
+        # The hostname of the redis work queue server
+        self.REDIS_QUEUE_SERVER_URL = "127.0.0.1"
+        # The port of the redis work queue server
+        self.REDIS_QUEUE_SERVER_PORT = 6379
+        # The password of the redis work queue server
+        self.REDIS_QUEUE_SERVER_PASSWORD = None
+        # This is the time the rq:job will be stored in redis
+        self.REDIS_QUEUE_JOB_TTL = None
+        # The prefix for the name of the redis worker queue.
+        # It will be extended by a numerical suffix that represents
+        # the worker id/number database to re-queue it, usually this is not
+        # necessary. If QUEUE_TYPE = perjob, it is extended by the
+        # resource_id of the job.
+        self.WORKER_QUEUE_PREFIX = "job_queue"
+        # Type of queue.
+        # "local":  Single queue for all jobs, processed by same actinia
+        #           instance via multiprocessing.
+        # "redis":  Number of queues is equal to number of workers as set
+        #           in config NUMBER_OF_WORKERS, processed by different
+        #           actinia instances (actinia worker).
+        # "perjob": Separate queue for each job, config for NUMBER_OF_WORKERS
+        #           is ignored. Processed by different actinia instance
+        #           (actinia worker). Resource_id will be added to above
+        #           WORKER_QUEUE_PREFIX.
+        # future ideas
+        # - redis separate queue per user
+        # - redis separate queue per process type
+        # - redis separate queue per ressource consumption
+        self.QUEUE_TYPE = "local"
 
         """
         MISC
@@ -293,7 +328,6 @@ class Configuration(object):
         config.set('LIMITS', 'MAX_CELL_LIMIT', str(self.MAX_CELL_LIMIT))
         config.set('LIMITS', 'PROCESS_TIME_LIMT', str(self.PROCESS_TIME_LIMT))
         config.set('LIMITS', 'PROCESS_NUM_LIMIT', str(self.PROCESS_NUM_LIMIT))
-        config.set('LIMITS', 'NUMBER_OF_WORKERS', str(self.NUMBER_OF_WORKERS))
 
         config.add_section('API')
         config.set('API', 'CHECK_CREDENTIALS', str(self.CHECK_CREDENTIALS))
@@ -309,14 +343,18 @@ class Configuration(object):
         config.set('REDIS', 'REDIS_SERVER_PW', str(self.REDIS_SERVER_PW))
         config.set('REDIS', 'REDIS_RESOURCE_EXPIRE_TIME',
                    str(self.REDIS_RESOURCE_EXPIRE_TIME))
-        config.set('REDIS', 'REDIS_QUEUE_SERVER_URL', self.REDIS_QUEUE_SERVER_URL)
-        config.set('REDIS', 'REDIS_QUEUE_SERVER_PORT',
-                   str(self.REDIS_QUEUE_SERVER_PORT))
-        config.set('REDIS', 'REDIS_QUEUE_SERVER_PASSWORD',
-                   str(self.REDIS_QUEUE_SERVER_PASSWORD))
-        config.set('REDIS', 'REDIS_QUEUE_JOB_TTL', str(self.REDIS_QUEUE_JOB_TTL))
-        config.set('REDIS', 'WORKER_QUEUE_NAME', str(self.WORKER_QUEUE_NAME))
         config.set('REDIS', 'WORKER_LOGFILE', str(self.WORKER_LOGFILE))
+
+        config.add_section('QUEUE')
+        config.set('QUEUE', 'NUMBER_OF_WORKERS', str(self.NUMBER_OF_WORKERS))
+        config.set('QUEUE', 'REDIS_QUEUE_SERVER_URL', self.REDIS_QUEUE_SERVER_URL)
+        config.set('QUEUE', 'REDIS_QUEUE_SERVER_PORT',
+                   str(self.REDIS_QUEUE_SERVER_PORT))
+        config.set('QUEUE', 'REDIS_QUEUE_SERVER_PASSWORD',
+                   str(self.REDIS_QUEUE_SERVER_PASSWORD))
+        config.set('QUEUE', 'REDIS_QUEUE_JOB_TTL', str(self.REDIS_QUEUE_JOB_TTL))
+        config.set('QUEUE', 'WORKER_QUEUE_PREFIX', str(self.WORKER_QUEUE_PREFIX))
+        config.set('QUEUE', 'QUEUE_TYPE', self.QUEUE_TYPE)
 
         config.add_section('MISC')
         config.set('MISC', 'DOWNLOAD_CACHE', self.DOWNLOAD_CACHE)
@@ -324,7 +362,6 @@ class Configuration(object):
         config.set('MISC', 'TMP_WORKDIR', self.TMP_WORKDIR)
         config.set('MISC', 'SECRET_KEY', self.SECRET_KEY)
         config.set('MISC', 'SAVE_INTERIM_RESULTS', str(self.SAVE_INTERIM_RESULTS))
-        config.set('MISC', 'QUEUE_TYPE', self.QUEUE_TYPE)
 
         config.add_section('LOGGING')
         config.set('LOGGING', 'LOG_INTERFACE', self.LOG_INTERFACE)
@@ -417,9 +454,6 @@ class Configuration(object):
                 if config.has_option("LIMITS", "PROCESS_NUM_LIMIT"):
                     self.PROCESS_NUM_LIMIT = config.getint(
                         "LIMITS", "PROCESS_NUM_LIMIT")
-                if config.has_option("LIMITS", "NUMBER_OF_WORKERS"):
-                    self.NUMBER_OF_WORKERS = config.getint(
-                        "LIMITS", "NUMBER_OF_WORKERS")
 
             if config.has_section("API"):
                 if config.has_option("API", "CHECK_CREDENTIALS"):
@@ -446,22 +480,30 @@ class Configuration(object):
                 if config.has_option("REDIS", "REDIS_RESOURCE_EXPIRE_TIME"):
                     self.REDIS_RESOURCE_EXPIRE_TIME = config.getint(
                         "REDIS", "REDIS_RESOURCE_EXPIRE_TIME")
-                if config.has_option("REDIS", "REDIS_QUEUE_SERVER_URL"):
-                    self.REDIS_QUEUE_SERVER_URL = config.get(
-                        "REDIS", "REDIS_QUEUE_SERVER_URL")
-                if config.has_option("REDIS", "REDIS_QUEUE_SERVER_PORT"):
-                    self.REDIS_QUEUE_SERVER_PORT = config.get(
-                        "REDIS", "REDIS_QUEUE_SERVER_PORT")
-                if config.has_option("REDIS", "REDIS_QUEUE_SERVER_PASSWORD"):
-                    self.REDIS_QUEUE_SERVER_PASSWORD = config.get(
-                        "REDIS", "REDIS_QUEUE_SERVER_PASSWORD")
-                if config.has_option("REDIS", "REDIS_QUEUE_JOB_TTL"):
-                    self.REDIS_QUEUE_JOB_TTL = config.get(
-                        "REDIS", "REDIS_QUEUE_JOB_TTL")
-                if config.has_option("REDIS", "WORKER_QUEUE_NAME"):
-                    self.WORKER_QUEUE_NAME = config.get("REDIS", "WORKER_QUEUE_NAME")
                 if config.has_option("REDIS", "WORKER_LOGFILE"):
                     self.WORKER_LOGFILE = config.get("REDIS", "WORKER_LOGFILE")
+
+            if config.has_section("QUEUE"):
+                if config.has_option("QUEUE", "NUMBER_OF_WORKERS"):
+                    self.NUMBER_OF_WORKERS = config.getint(
+                    "QUEUE", "NUMBER_OF_WORKERS")
+                if config.has_option("QUEUE", "REDIS_QUEUE_SERVER_URL"):
+                    self.REDIS_QUEUE_SERVER_URL = config.get(
+                        "QUEUE", "REDIS_QUEUE_SERVER_URL")
+                if config.has_option("QUEUE", "REDIS_QUEUE_SERVER_PORT"):
+                    self.REDIS_QUEUE_SERVER_PORT = config.get(
+                        "QUEUE", "REDIS_QUEUE_SERVER_PORT")
+                if config.has_option("QUEUE", "REDIS_QUEUE_SERVER_PASSWORD"):
+                    self.REDIS_QUEUE_SERVER_PASSWORD = config.get(
+                        "QUEUE", "REDIS_QUEUE_SERVER_PASSWORD")
+                if config.has_option("QUEUE", "REDIS_QUEUE_JOB_TTL"):
+                    self.REDIS_QUEUE_JOB_TTL = config.get(
+                        "QUEUE", "REDIS_QUEUE_JOB_TTL")
+                if config.has_option("QUEUE", "WORKER_QUEUE_PREFIX"):
+                    self.WORKER_QUEUE_PREFIX = config.get("QUEUE", "WORKER_QUEUE_PREFIX")
+                if config.has_option("QUEUE", "QUEUE_TYPE"):
+                    self.QUEUE_TYPE = config.get(
+                        "QUEUE", "QUEUE_TYPE")
 
             if config.has_section("MISC"):
                 if config.has_option("MISC", "DOWNLOAD_CACHE"):
@@ -478,9 +520,6 @@ class Configuration(object):
                 if config.has_option("MISC", "SAVE_INTERIM_RESULTS"):
                     self.SAVE_INTERIM_RESULTS = config.getboolean(
                         "MISC", "SAVE_INTERIM_RESULTS")
-                if config.has_option("MISC", "QUEUE_TYPE"):
-                    self.QUEUE_TYPE = config.get(
-                        "MISC", "QUEUE_TYPE")
 
             if config.has_section("LOGGING"):
                 if config.has_option("LOGGING", "LOG_INTERFACE"):

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -486,7 +486,7 @@ class Configuration(object):
             if config.has_section("QUEUE"):
                 if config.has_option("QUEUE", "NUMBER_OF_WORKERS"):
                     self.NUMBER_OF_WORKERS = config.getint(
-                    "QUEUE", "NUMBER_OF_WORKERS")
+                        "QUEUE", "NUMBER_OF_WORKERS")
                 if config.has_option("QUEUE", "REDIS_QUEUE_SERVER_URL"):
                     self.REDIS_QUEUE_SERVER_URL = config.get(
                         "QUEUE", "REDIS_QUEUE_SERVER_URL")
@@ -500,7 +500,8 @@ class Configuration(object):
                     self.REDIS_QUEUE_JOB_TTL = config.get(
                         "QUEUE", "REDIS_QUEUE_JOB_TTL")
                 if config.has_option("QUEUE", "WORKER_QUEUE_PREFIX"):
-                    self.WORKER_QUEUE_PREFIX = config.get("QUEUE", "WORKER_QUEUE_PREFIX")
+                    self.WORKER_QUEUE_PREFIX = config.get(
+                        "QUEUE", "WORKER_QUEUE_PREFIX")
                 if config.has_option("QUEUE", "QUEUE_TYPE"):
                     self.QUEUE_TYPE = config.get(
                         "QUEUE", "QUEUE_TYPE")

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -212,7 +212,7 @@ class Configuration(object):
         # "redis":  Number of queues is equal to number of workers as set
         #           in config NUMBER_OF_WORKERS, processed by different
         #           actinia instances (actinia worker).
-        # "perjob": Separate queue for each job, config for NUMBER_OF_WORKERS
+        # "per_job": Separate queue for each job, config for NUMBER_OF_WORKERS
         #           is ignored. Processed by different actinia instance
         #           (actinia worker). Resource_id will be added to above
         #           WORKER_QUEUE_PREFIX.

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -203,7 +203,7 @@ class Configuration(object):
         # The prefix for the name of the redis worker queue.
         # It will be extended by a numerical suffix that represents
         # the worker id/number database to re-queue it, usually this is not
-        # necessary. If QUEUE_TYPE = perjob, it is extended by the
+        # necessary. If QUEUE_TYPE = per_job, it is extended by the
         # resource_id of the job.
         self.WORKER_QUEUE_PREFIX = "job_queue"
         # Type of queue.

--- a/src/actinia_core/core/common/redis_interface.py
+++ b/src/actinia_core/core/common/redis_interface.py
@@ -125,7 +125,7 @@ def enqueue_job(timeout, func, *args):
     global job_queues, redis_conn
     num_queues = global_config.NUMBER_OF_WORKERS
 
-    if (global_config.QUEUE_TYPE == "perjob"):
+    if (global_config.QUEUE_TYPE == "per_job"):
         resource_id = args[0].resource_id
         queue_name = "%s_%s" % (global_config.WORKER_QUEUE_PREFIX, resource_id)
         __create_job_queue(queue_name)

--- a/src/actinia_core/core/common/redis_interface.py
+++ b/src/actinia_core/core/common/redis_interface.py
@@ -4,7 +4,7 @@
 # performance processing of geographical data that uses GRASS GIS for
 # computational tasks. For details, see https://actinia.mundialis.de/
 #
-# Copyright (c) 2016-2018 Sören Gebbert and mundialis GmbH & Co. KG
+# Copyright (c) 2016-2022 Sören Gebbert and mundialis GmbH & Co. KG
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,118 +33,12 @@ from .config import global_config
 from .process_queue import enqueue_job as enqueue_job_local
 
 __license__ = "GPLv3"
-__author__ = "Sören Gebbert"
-__copyright__ = "Copyright 2016-2018, Sören Gebbert and mundialis GmbH & Co. KG"
-__maintainer__ = "Sören Gebbert"
-__email__ = "soerengebbert@googlemail.com"
+__author__ = "Sören Gebbert, Carmen Tawalika"
+__copyright__ = "Copyright 2016-2022, Sören Gebbert and mundialis GmbH & Co. KG"
+__maintainer__ = "mundialis"
 
-# Job handling
 job_queues = []
 redis_conn = None
-num_queues = None
-
-
-def __create_job_queues(host, port, password, num_of_queues):
-    """Create the job queues for asynchronous processing
-
-    TODO: The redis queue approach does not work and is deactivated
-
-    Note:
-        Make sure that the global configuration was updated
-        before calling this function.
-
-    Args:
-        host: The hostname of the redis server
-        port: The port of the redis server
-        num_of_queues: The number of queues that should be created
-
-    """
-    # Redis work queue and connection
-    global job_queues, redis_conn, num_queues
-    kwargs = dict()
-    kwargs['host'] = host
-    kwargs['port'] = port
-    if password and password is not None:
-        kwargs['password'] = password
-    redis_conn = Redis(**kwargs)
-    num_queues = num_of_queues
-
-    for i in range(num_of_queues):
-        name = "%s_%i" % (global_config.WORKER_QUEUE_NAME, i)
-
-        string = "Create queue %s with server %s:%s" % (name, host, port)
-        log.info(string)
-        queue = rq.Queue(name, connection=redis_conn)
-        job_queues.append(queue)
-
-
-def __enqueue_job_local(timeout, func, *args):
-    """Execute the provided function in a subprocess
-
-    Args:
-        func: The function to call from the subprocess
-        *args: The function arguments
-
-    Returns:
-        int:
-        The current queue index
-
-    """
-    enqueue_job_local(timeout, func, *args)
-    return
-
-    # Just i case the current process queue does not work
-    # Then use the most simple solution by just starting the process
-    from multiprocessing import Process
-    p = Process(target=func, args=args)
-    p.start()
-
-    return
-
-
-def __enqueue_job_redis(timeout, func, *args):
-    """Enqueue a job in the job queues
-
-    TODO: The redis queue approach does not work and is deactivated
-
-    The enqueue function uses a redis incr approach
-    to chose for each job a different queue
-
-    Note:
-        The function __create_job_queues() must be run
-        before a job can be enqueued.
-
-    Args:
-        func: The function to call from the subprocess
-        *args: The function arguments
-
-    Returns:
-        int:
-        The current queue index
-
-    """
-
-    global job_queues, redis_conn, num_queues
-
-    # Increase the counter
-    num = redis_conn.incr("actinia_worker_count", 1)
-    # Compute the current
-    current_queue = num % num_queues
-    log.info("Enqueue job in queue %i" % current_queue)
-
-    # Below timeout is defined in resource_base.pyL295:
-    # int(process_time_limit * process_num_limit * 20)
-    # which is 630720000000 and raises in worker:
-    # OverflowError: Python int too large to convert to C int
-    ret = job_queues[current_queue].enqueue(
-        func,
-        *args,
-        # job_timeout=timeout,
-        ttl=global_config.REDIS_QUEUE_JOB_TTL,
-        result_ttl=global_config.REDIS_QUEUE_JOB_TTL)
-    log.info(ret)
-
-    return current_queue
 
 
 def connect(host, port, pw=None):
@@ -171,17 +65,91 @@ def disconnect():
     redis_api_log_interface.disconnect()
 
 
+def __create_job_queue(queue_name):
+    """Create a single job queue for asynchronous processing
+
+    Args:
+        queue_name: The name of the queue
+
+    """
+    # Redis work queue and connection
+    global job_queues, redis_conn
+
+    host = global_config.REDIS_QUEUE_SERVER_URL
+    port = global_config.REDIS_QUEUE_SERVER_PORT
+    password = global_config.REDIS_QUEUE_SERVER_PASSWORD
+
+    kwargs = dict()
+    kwargs['host'] = host
+    kwargs['port'] = port
+    if password and password is not None:
+        kwargs['password'] = password
+    redis_conn = Redis(**kwargs)
+
+    string = "Create queue %s with server %s:%s" % (queue_name, host, port)
+    log.info(string)
+    queue = rq.Queue(queue_name, connection=redis_conn)
+    job_queues.append(queue)
+
+
+def __enqueue_job_redis(queue, timeout, func, *args):
+    """Enqueue a job in the job queues
+
+    Args:
+        func: The function to call from the subprocess
+        *args: The function arguments
+    """
+
+    log.info("Enqueue job in queue %s" % queue.name)
+    # Below timeout is defined in resource_base.pyL295:
+    # int(process_time_limit * process_num_limit * 20)
+    # which is 630720000000 and raises in worker:
+    # OverflowError: Python int too large to convert to C int
+    ret = queue.enqueue(
+        func,
+        *args,
+        # job_timeout=timeout,
+        ttl=global_config.REDIS_QUEUE_JOB_TTL,
+        result_ttl=global_config.REDIS_QUEUE_JOB_TTL)
+    log.info(ret)
+
+
 def enqueue_job(timeout, func, *args):
+    """Write the provided function in a queue
 
-    global job_queues
+    Args:
+        timeout: The timeout of the process
+        func: The function to call from the subprocess/worker
+        *args: The function arguments
+    """
+    global job_queues, redis_conn
+    num_queues = global_config.NUMBER_OF_WORKERS
 
-    if job_queues == []:
-        __create_job_queues(global_config.REDIS_QUEUE_SERVER_URL,
-                            global_config.REDIS_QUEUE_SERVER_PORT,
-                            global_config.REDIS_QUEUE_SERVER_PASSWORD,
-                            global_config.NUMBER_OF_WORKERS)
+    if (global_config.QUEUE_TYPE == "perjob"):
+        resource_id = args[0].resource_id
+        queue_name = "%s_%s" % (global_config.WORKER_QUEUE_PREFIX, resource_id)
+        __create_job_queue(queue_name)
+        for i in job_queues:
+            if i.name == queue_name:
+                __enqueue_job_redis(i, timeout, func, *args)
 
-    if (global_config.QUEUE_TYPE == "redis"):
-        __enqueue_job_redis(timeout, func, *args)
+    elif (global_config.QUEUE_TYPE == "redis"):
+        if job_queues == []:
+            for i in range(num_queues):
+                queue_name = "%s_%s" % (global_config.WORKER_QUEUE_PREFIX, i)
+                __create_job_queue(queue_name)
+        # The redis incr approach is used here
+        # to chose for each job a different queue
+        num = redis_conn.incr("actinia_worker_count", 1)
+        current_queue = num % num_queues
+        __enqueue_job_redis(job_queues[current_queue], timeout, func, *args)
+
     elif (global_config.QUEUE_TYPE == "local"):
-        __enqueue_job_local(timeout, func, *args)
+        # __enqueue_job_local(timeout, func, *args)
+        enqueue_job_local(timeout, func, *args)
+        return
+        # Just in case the current process queue does not work
+        # Then use the most simple solution by just starting the process
+        from multiprocessing import Process
+        p = Process(target=func, args=args)
+        p.start()


### PR DESCRIPTION
**This PR**
- allows to specify a separate queue for each job, `resource_id` included in queue  name
- adds a README for actinia redis queue
- adjusts dependency README
- adds a new block `QUEUE` to config and moves other entries to it
- refactors `redis_interface.py` while adding new functionality (see first bullet)

When a request is made which writes a job in the queue, actinia logs the following:
```
[2022-07-01 08:51:24,222] INFO      : actinia-core.redis_interface -Create queue job_queue_resource_id-0a151f6c-91c5-478c-84b8-57fb4ce5f052 with server redis-queue:6379 [in /src/actinia_core/src/actinia_core/core/common/redis_interface.py:90]
[2022-07-01 08:51:24,224] INFO      : actinia-core.redis_interface -Enqueue job in queue job_queue_resource_id-0a151f6c-91c5-478c-84b8-57fb4ce5f052 [in /src/actinia_core/src/actinia_core/core/common/redis_interface.py:103]
```
Then the actinia-worker can be started with:
```
rq_custom_worker job_queue_resource_id-0a151f6c-91c5-478c-84b8-57fb4ce5f052 -c /etc/default/actinia
```
**TODO**:
(in separate MR): return queue name in response when job is started.

**DISCUSS:**
The changes in the config (e.g. `LIMITS.NUMBEROF_WORKERS` -> `QUEUE.NUMBER_OF_WORKERS`) are not affecting the use of the values within actinia and plugins but all existing config files. If the old values are used, no error appears but the config is simply not used. As all attributes which were moved are only relevant if the redis queue is used and this was only reactivated a few month ago in [this PR](https://github.com/mundialis/actinia_core/pull/304), I would argue that it is not widespread yet and not a problem, but comments welcome.
