### PR TITLE
Always use local queue for sync requests

### DIFF
--- a/redis_queue.md
+++ b/redis_queue.md
@@ -25,7 +25,7 @@ docker-compose -f actinia-docker/docker-compose-dev-rq.yml run --rm --service-po
 - inside container, start worker listening to specified queue
 ```
 QUEUE_NAME=job_queue_0
-rq_custom_worker $QUEUE_NAME -c /etc/default/actinia
+rq_custom_worker $QUEUE_NAME -c /etc/default/actinia --quit
 ```
 
 

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -223,6 +223,9 @@ class Configuration(object):
         # - redis separate queue per process type
         # - redis separate queue per ressource consumption
         self.QUEUE_TYPE = "local"
+        # Separate configuration for queue_type for synchronous requests which
+        # might not want to be queued.
+        self.QUEUE_TYPE_OVERWRITE = "local"
 
         """
         MISC
@@ -236,9 +239,6 @@ class Configuration(object):
         self.DOWNLOAD_CACHE_QUOTA = 100
         # If True the interim results (temporary mapset) are saved
         self.SAVE_INTERIM_RESULTS = False
-        # Type of queue. Can be "local" or "redis". If redis is set, job can
-        # be received and executed from different actinia instances
-        self.QUEUE_TYPE = "local"
 
         """
         LOGGING
@@ -358,6 +358,7 @@ class Configuration(object):
         config.set('QUEUE', 'REDIS_QUEUE_JOB_TTL', str(self.REDIS_QUEUE_JOB_TTL))
         config.set('QUEUE', 'WORKER_QUEUE_PREFIX', str(self.WORKER_QUEUE_PREFIX))
         config.set('QUEUE', 'QUEUE_TYPE', self.QUEUE_TYPE)
+        config.set('QUEUE', 'QUEUE_TYPE_OVERWRITE', self.QUEUE_TYPE_OVERWRITE)
 
         config.add_section('MISC')
         config.set('MISC', 'DOWNLOAD_CACHE', self.DOWNLOAD_CACHE)
@@ -510,6 +511,9 @@ class Configuration(object):
                 if config.has_option("QUEUE", "QUEUE_TYPE"):
                     self.QUEUE_TYPE = config.get(
                         "QUEUE", "QUEUE_TYPE")
+                if config.has_option("QUEUE", "QUEUE_TYPE_OVERWRITE"):
+                    self.QUEUE_TYPE_OVERWRITE = config.get(
+                        "QUEUE", "QUEUE_TYPE_OVERWRITE")
 
             if config.has_section("MISC"):
                 if config.has_option("MISC", "DOWNLOAD_CACHE"):

--- a/src/actinia_core/core/common/redis_interface.py
+++ b/src/actinia_core/core/common/redis_interface.py
@@ -126,7 +126,7 @@ def enqueue_job(timeout, func, *args, queue_type_overwrite=None):
     num_queues = global_config.NUMBER_OF_WORKERS
     queue_type = global_config.QUEUE_TYPE
     if queue_type_overwrite:
-        queue_type = queue_type_overwrite
+        queue_type = global_config.QUEUE_TYPE_OVERWRITE
 
     if (queue_type == "per_job"):
         resource_id = args[0].resource_id

--- a/src/actinia_core/core/common/redis_interface.py
+++ b/src/actinia_core/core/common/redis_interface.py
@@ -114,7 +114,7 @@ def __enqueue_job_redis(queue, timeout, func, *args):
     log.info(ret)
 
 
-def enqueue_job(timeout, func, *args):
+def enqueue_job(timeout, func, *args, queue_type_overwrite):
     """Write the provided function in a queue
 
     Args:
@@ -124,8 +124,11 @@ def enqueue_job(timeout, func, *args):
     """
     global job_queues, redis_conn
     num_queues = global_config.NUMBER_OF_WORKERS
+    queue_type = global_config.QUEUE_TYPE
+    if queue_type_overwrite:
+        queue_type = queue_type_overwrite
 
-    if (global_config.QUEUE_TYPE == "per_job"):
+    if (queue_type == "per_job"):
         resource_id = args[0].resource_id
         queue_name = "%s_%s" % (global_config.WORKER_QUEUE_PREFIX, resource_id)
         __create_job_queue(queue_name)
@@ -133,7 +136,7 @@ def enqueue_job(timeout, func, *args):
             if i.name == queue_name:
                 __enqueue_job_redis(i, timeout, func, *args)
 
-    elif (global_config.QUEUE_TYPE == "redis"):
+    elif (queue_type == "redis"):
         if job_queues == []:
             for i in range(num_queues):
                 queue_name = "%s_%s" % (global_config.WORKER_QUEUE_PREFIX, i)
@@ -144,7 +147,7 @@ def enqueue_job(timeout, func, *args):
         current_queue = num % num_queues
         __enqueue_job_redis(job_queues[current_queue], timeout, func, *args)
 
-    elif (global_config.QUEUE_TYPE == "local"):
+    elif (queue_type == "local"):
         # __enqueue_job_local(timeout, func, *args)
         enqueue_job_local(timeout, func, *args)
         return

--- a/src/actinia_core/core/common/redis_interface.py
+++ b/src/actinia_core/core/common/redis_interface.py
@@ -114,7 +114,7 @@ def __enqueue_job_redis(queue, timeout, func, *args):
     log.info(ret)
 
 
-def enqueue_job(timeout, func, *args, queue_type_overwrite):
+def enqueue_job(timeout, func, *args, queue_type_overwrite=None):
     """Write the provided function in a queue
 
     Args:

--- a/src/actinia_core/rest/base/endpoint_config.py
+++ b/src/actinia_core/rest/base/endpoint_config.py
@@ -67,6 +67,9 @@ def check_endpoint(method, api_doc=None, endpoint_class=None):
 
 
 def endpoint_decorator():
+    """Check whether an endpoint allowlist should be used to
+    allow only the provided list of endpoints and hide all others.
+    """
 
     def decorator(func):
         endpoint_class, method = func.__qualname__.split(".")
@@ -82,6 +85,23 @@ def endpoint_decorator():
                     status="error",
                     message="Not Found. The requested URL is not configured on"
                             " the server.")), 404)
+        return wrapper
+
+    return decorator
+
+
+def check_queue_type_overwrite():
+    """Always use local queue for synchronous requests to respond in time.
+    Decorator is used here so it is more easy to change later.
+    """
+
+    def decorator(func):
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            result = func(*args, **kwargs, queue_type_overwrite='local')
+            return result
+
         return wrapper
 
     return decorator

--- a/src/actinia_core/rest/base/endpoint_config.py
+++ b/src/actinia_core/rest/base/endpoint_config.py
@@ -90,18 +90,18 @@ def endpoint_decorator():
     return decorator
 
 
-def check_queue_type_overwrite():
-    """Always use local queue for synchronous requests to respond in time.
-    Decorator is used here so it is more easy to change later.
-    """
+# def check_queue_type_overwrite():
+#     """Always use local queue for synchronous requests to respond in time.
+#     Decorator is used here so it is more easy to change later.
+#     """
 
-    def decorator(func):
+#     def decorator(func):
 
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            result = func(*args, **kwargs, queue_type_overwrite='local')
-            return result
+#         @wraps(func)
+#         def wrapper(*args, **kwargs):
+#             result = func(*args, **kwargs, queue_type_overwrite='local')
+#             return result
 
-        return wrapper
+#         return wrapper
 
-    return decorator
+#     return decorator

--- a/src/actinia_core/rest/download_cache_management.py
+++ b/src/actinia_core/rest/download_cache_management.py
@@ -37,7 +37,8 @@ from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.core.common.api_logger import log_api_call
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator
+    endpoint_decorator,
+    check_queue_type_overwrite
 )
 from actinia_core.rest.base.user_auth import check_admin_role
 from actinia_core.rest.base.user_auth import check_user_permissions
@@ -55,28 +56,34 @@ class SyncDownloadCacheResource(ResourceBase):
     decorators = [log_api_call, check_user_permissions,
                   check_admin_role, auth.login_required]
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", download_cache_management.get_doc))
-    def get(self):
+    def get(self, queue_type_overwrite=None):
         """Get the current size of the download cache"""
         rdc = self.preprocess(has_json=False, has_xml=False)
 
         if rdc:
-            enqueue_job(self.job_timeout, start_download_cache_size, rdc)
+            enqueue_job(
+                self.job_timeout, start_download_cache_size, rdc,
+                queue_type_overwrite=queue_type_overwrite)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)
 
         return make_response(jsonify(response_model), http_code)
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("delete", download_cache_management.delete_doc))
-    def delete(self):
+    def delete(self, queue_type_overwrite=None):
         """Clean the download cache and remove all cached data"""
         rdc = self.preprocess(has_json=False, has_xml=False)
 
         if rdc:
-            enqueue_job(self.job_timeout, start_download_cache_remove, rdc)
+            enqueue_job(
+                self.job_timeout, start_download_cache_remove, rdc,
+                queue_type_overwrite=queue_type_overwrite)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)

--- a/src/actinia_core/rest/download_cache_management.py
+++ b/src/actinia_core/rest/download_cache_management.py
@@ -37,8 +37,7 @@ from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.core.common.api_logger import log_api_call
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.rest.base.user_auth import check_admin_role
 from actinia_core.rest.base.user_auth import check_user_permissions
@@ -56,34 +55,32 @@ class SyncDownloadCacheResource(ResourceBase):
     decorators = [log_api_call, check_user_permissions,
                   check_admin_role, auth.login_required]
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", download_cache_management.get_doc))
-    def get(self, queue_type_overwrite=None):
+    def get(self):
         """Get the current size of the download cache"""
         rdc = self.preprocess(has_json=False, has_xml=False)
 
         if rdc:
             enqueue_job(
                 self.job_timeout, start_download_cache_size, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)
 
         return make_response(jsonify(response_model), http_code)
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("delete", download_cache_management.delete_doc))
-    def delete(self, queue_type_overwrite=None):
+    def delete(self):
         """Clean the download cache and remove all cached data"""
         rdc = self.preprocess(has_json=False, has_xml=False)
 
         if rdc:
             enqueue_job(
                 self.job_timeout, start_download_cache_remove, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)

--- a/src/actinia_core/rest/location_management.py
+++ b/src/actinia_core/rest/location_management.py
@@ -40,8 +40,7 @@ from actinia_core.core.common.app import auth
 from actinia_core.core.common.api_logger import log_api_call
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.rest.base.user_auth import check_admin_role
 from actinia_core.rest.base.user_auth import check_user_permissions
@@ -120,10 +119,9 @@ class LocationManagementResourceUser(ResourceBase):
     def __init__(self):
         ResourceBase.__init__(self)
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", location_management.get_user_doc))
-    def get(self, location_name, queue_type_overwrite=None):
+    def get(self, location_name):
         """Get the location projection and current computational region of the PERMANENT mapset
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -132,7 +130,7 @@ class LocationManagementResourceUser(ResourceBase):
         if rdc:
             enqueue_job(
                 self.job_timeout, read_current_region, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)

--- a/src/actinia_core/rest/map_layer_management.py
+++ b/src/actinia_core/rest/map_layer_management.py
@@ -32,8 +32,7 @@ from actinia_api.swagger2.actinia_core.apidocs import map_layer_management
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.core.request_parser import glist_parser
 from actinia_core.rest.base.resource_base import ResourceBase
@@ -53,8 +52,7 @@ class MapsetLayersResource(ResourceBase):
         ResourceBase.__init__(self)
         self.layer_type = layer_type
 
-    @check_queue_type_overwrite()
-    def _get(self, location_name, mapset_name, queue_type_overwrite=None):
+    def _get(self, location_name, mapset_name):
         """Return a collection of all available layers
         in the provided mapset.
 
@@ -97,15 +95,14 @@ class MapsetLayersResource(ResourceBase):
             rdc.set_user_data((args, self.layer_type))
             enqueue_job(
                 self.job_timeout, list_raster_layers, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)
 
         return make_response(jsonify(response_model), http_code)
 
-    @check_queue_type_overwrite()
-    def _delete(self, location_name, mapset_name, queue_type_overwrite=None):
+    def _delete(self, location_name, mapset_name):
         """Remove a list of layers identified by a pattern
 
         The g.remove "pattern" parameters must be provided::
@@ -130,7 +127,7 @@ class MapsetLayersResource(ResourceBase):
             rdc.set_user_data((args, self.layer_type))
             enqueue_job(
                 self.job_timeout, remove_raster_layers, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)

--- a/src/actinia_core/rest/mapset_management.py
+++ b/src/actinia_core/rest/mapset_management.py
@@ -40,8 +40,7 @@ from actinia_core.core.common.api_logger import log_api_call
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.rest.base.user_auth import check_user_permissions
 from actinia_core.rest.base.user_auth import check_admin_role
@@ -60,10 +59,10 @@ class ListMapsetsResource(ResourceBase):
     """
     layer_type = None
 
-    @check_queue_type_overwrite()
+    # @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", mapset_management.get_doc))
-    def get(self, location_name, queue_type_overwrite=None):
+    def get(self, location_name):
         """Get a list of all mapsets that are located in a specific location.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -72,7 +71,7 @@ class ListMapsetsResource(ResourceBase):
         if rdc:
             enqueue_job(
                 self.job_timeout, list_raster_mapsets, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)
@@ -87,10 +86,9 @@ class MapsetManagementResourceUser(ResourceBase):
     def __init__(self):
         ResourceBase.__init__(self)
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", mapset_management.get_user_doc))
-    def get(self, location_name, mapset_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name):
         """Get the current computational region of the mapset and the projection
         of the location as WKT string.
         """
@@ -100,7 +98,7 @@ class MapsetManagementResourceUser(ResourceBase):
 
         enqueue_job(
             self.job_timeout, read_current_region, rdc,
-            queue_type_overwrite=queue_type_overwrite)
+            queue_type_overwrite=True)
         http_code, response_model = self.wait_until_finish()
         return make_response(jsonify(response_model), http_code)
 
@@ -145,10 +143,9 @@ class MapsetManagementResourceAdmin(ResourceBase):
         """
         pass
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("delete", mapset_management.delete_admin_doc))
-    def delete(self, location_name, mapset_name, queue_type_overwrite=None):
+    def delete(self, location_name, mapset_name):
         """Delete an existing mapset.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -157,7 +154,7 @@ class MapsetManagementResourceAdmin(ResourceBase):
 
         enqueue_job(
             self.job_timeout, delete_mapset, rdc,
-            queue_type_overwrite=queue_type_overwrite)
+            queue_type_overwrite=True)
         http_code, response_model = self.wait_until_finish()
         return make_response(jsonify(response_model), http_code)
 
@@ -168,10 +165,9 @@ class MapsetLockManagementResource(ResourceBase):
     decorators = [log_api_call, check_user_permissions,
                   check_admin_role, auth.login_required]
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", mapset_management.get_lock_doc))
-    def get(self, location_name, mapset_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name):
         """Get the location/mapset lock status.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -180,7 +176,7 @@ class MapsetLockManagementResource(ResourceBase):
 
         enqueue_job(
             self.job_timeout, get_mapset_lock, rdc,
-            queue_type_overwrite=queue_type_overwrite)
+            queue_type_overwrite=True)
         http_code, response_model = self.wait_until_finish()
         return make_response(jsonify(response_model), http_code)
 
@@ -197,10 +193,9 @@ class MapsetLockManagementResource(ResourceBase):
         http_code, response_model = self.wait_until_finish()
         return make_response(jsonify(response_model), http_code)
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("delete", mapset_management.delete_lock_doc))
-    def delete(self, location_name, mapset_name, queue_type_overwrite=None):
+    def delete(self, location_name, mapset_name):
         """Delete a location/mapset lock.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -209,6 +204,6 @@ class MapsetLockManagementResource(ResourceBase):
 
         enqueue_job(
             self.job_timeout, unlock_mapset, rdc,
-            queue_type_overwrite=queue_type_overwrite)
+            queue_type_overwrite=True)
         http_code, response_model = self.wait_until_finish()
         return make_response(jsonify(response_model), http_code)

--- a/src/actinia_core/rest/raster_colors.py
+++ b/src/actinia_core/rest/raster_colors.py
@@ -34,8 +34,7 @@ from actinia_api.swagger2.actinia_core.apidocs import raster_colors
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.rest.base.resource_base import ResourceBase
 from actinia_core.processing.common.raster_colors import start_job_colors_out
@@ -51,10 +50,9 @@ class SyncPersistentRasterColorsResource(ResourceBase):
     """Manage the color table
     """
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", raster_colors.get_doc))
-    def get(self, location_name, mapset_name, raster_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name, raster_name):
         """Get the color definition of an existing raster map layer.
 
         Args:
@@ -70,7 +68,7 @@ class SyncPersistentRasterColorsResource(ResourceBase):
 
         enqueue_job(
             self.job_timeout, start_job_colors_out, rdc,
-            queue_type_overwrite=queue_type_overwrite)
+            queue_type_overwrite=True)
         http_code, response_model = self.wait_until_finish()
         return make_response(jsonify(response_model), http_code)
 

--- a/src/actinia_core/rest/raster_colors.py
+++ b/src/actinia_core/rest/raster_colors.py
@@ -34,7 +34,8 @@ from actinia_api.swagger2.actinia_core.apidocs import raster_colors
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator
+    endpoint_decorator,
+    check_queue_type_overwrite
 )
 from actinia_core.rest.base.resource_base import ResourceBase
 from actinia_core.processing.common.raster_colors import start_job_colors_out
@@ -50,9 +51,10 @@ class SyncPersistentRasterColorsResource(ResourceBase):
     """Manage the color table
     """
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", raster_colors.get_doc))
-    def get(self, location_name, mapset_name, raster_name):
+    def get(self, location_name, mapset_name, raster_name, queue_type_overwrite=None):
         """Get the color definition of an existing raster map layer.
 
         Args:
@@ -66,7 +68,9 @@ class SyncPersistentRasterColorsResource(ResourceBase):
                               mapset_name=mapset_name,
                               map_name=raster_name)
 
-        enqueue_job(self.job_timeout, start_job_colors_out, rdc)
+        enqueue_job(
+            self.job_timeout, start_job_colors_out, rdc,
+            queue_type_overwrite=queue_type_overwrite)
         http_code, response_model = self.wait_until_finish()
         return make_response(jsonify(response_model), http_code)
 

--- a/src/actinia_core/rest/raster_layer.py
+++ b/src/actinia_core/rest/raster_layer.py
@@ -35,8 +35,7 @@ from actinia_api.swagger2.actinia_core.apidocs import raster_layer
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.core.utils import allowed_file
 from actinia_core.models.response_models import SimpleResponseModel
@@ -54,10 +53,9 @@ class RasterLayerResource(MapLayerRegionResourceBase):
     """Return information about a specific raster layer as JSON
     """
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", raster_layer.get_doc))
-    def get(self, location_name, mapset_name, raster_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name, raster_name):
         """Get information about an existing raster map layer.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -67,18 +65,17 @@ class RasterLayerResource(MapLayerRegionResourceBase):
         if rdc:
             enqueue_job(
                 self.job_timeout, start_info_job, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish(0.02)
         else:
             http_code, response_model = pickle.loads(self.response_data)
 
         return make_response(jsonify(response_model), http_code)
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("delete", raster_layer.delete_doc))
     def delete(
-            self, location_name, mapset_name, raster_name, queue_type_overwrite=None):
+            self, location_name, mapset_name, raster_name):
         """Delete an existing raster map layer.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -88,7 +85,7 @@ class RasterLayerResource(MapLayerRegionResourceBase):
         if rdc:
             enqueue_job(
                 self.job_timeout, start_delete_job, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish(0.1)
         else:
             http_code, response_model = pickle.loads(self.response_data)

--- a/src/actinia_core/rest/raster_legend.py
+++ b/src/actinia_core/rest/raster_legend.py
@@ -33,8 +33,7 @@ from actinia_api.swagger2.actinia_core.apidocs import raster_legend
 
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.rest.base.resource_base import ResourceBase
@@ -119,10 +118,9 @@ class SyncEphemeralRasterLegendResource(ResourceBase):
 
         return options
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", raster_legend.get_doc))
-    def get(self, location_name, mapset_name, raster_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name, raster_name):
         """Render the legend of a raster map layer as a PNG image.
         """
         parser = self.create_parser()
@@ -141,7 +139,7 @@ class SyncEphemeralRasterLegendResource(ResourceBase):
 
         enqueue_job(
             self.job_timeout, start_job, rdc,
-            queue_type_overwrite=queue_type_overwrite)
+            queue_type_overwrite=True)
 
         http_code, response_model = self.wait_until_finish(0.05)
         if http_code == 200:

--- a/src/actinia_core/rest/raster_legend.py
+++ b/src/actinia_core/rest/raster_legend.py
@@ -33,7 +33,8 @@ from actinia_api.swagger2.actinia_core.apidocs import raster_legend
 
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator
+    endpoint_decorator,
+    check_queue_type_overwrite
 )
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.rest.base.resource_base import ResourceBase
@@ -118,9 +119,10 @@ class SyncEphemeralRasterLegendResource(ResourceBase):
 
         return options
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", raster_legend.get_doc))
-    def get(self, location_name, mapset_name, raster_name):
+    def get(self, location_name, mapset_name, raster_name, queue_type_overwrite=None):
         """Render the legend of a raster map layer as a PNG image.
         """
         parser = self.create_parser()
@@ -137,7 +139,9 @@ class SyncEphemeralRasterLegendResource(ResourceBase):
 
         rdc.set_user_data(options)
 
-        enqueue_job(self.job_timeout, start_job, rdc)
+        enqueue_job(
+            self.job_timeout, start_job, rdc,
+            queue_type_overwrite=queue_type_overwrite)
 
         http_code, response_model = self.wait_until_finish(0.05)
         if http_code == 200:

--- a/src/actinia_core/rest/raster_renderer.py
+++ b/src/actinia_core/rest/raster_renderer.py
@@ -32,8 +32,7 @@ from actinia_api.swagger2.actinia_core.apidocs import raster_renderer
 
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.rest.base.renderer_base import RendererBaseResource
@@ -50,10 +49,9 @@ class SyncEphemeralRasterRendererResource(RendererBaseResource):
     """Render a raster image with g.region/d.rast approach synchronously
     """
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", raster_renderer.raster_render_get_doc))
-    def get(self, location_name, mapset_name, raster_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name, raster_name):
         """Render a raster map layer as a PNG image.
         """
         parser = self.create_parser()
@@ -72,7 +70,7 @@ class SyncEphemeralRasterRendererResource(RendererBaseResource):
 
         enqueue_job(
             self.job_timeout, start_job, rdc,
-            queue_type_overwrite=queue_type_overwrite)
+            queue_type_overwrite=True)
 
         http_code, response_model = self.wait_until_finish(0.05)
         if http_code == 200:
@@ -123,11 +121,10 @@ class SyncEphemeralRasterRGBRendererResource(RendererBaseResource):
 
         return options
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint(
         "get", raster_renderer.raster_rgb_render_get_doc))
-    def get(self, location_name, mapset_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name):
         """Render three raster map layer as composed RGB PNG image.
         """
 
@@ -156,7 +153,7 @@ class SyncEphemeralRasterRGBRendererResource(RendererBaseResource):
 
         enqueue_job(
             self.job_timeout, start_rgb_job, rdc,
-            queue_type_overwrite=queue_type_overwrite)
+            queue_type_overwrite=True)
 
         http_code, response_model = self.wait_until_finish(0.05)
         if http_code == 200:
@@ -204,11 +201,10 @@ class SyncEphemeralRasterShapeRendererResource(RendererBaseResource):
 
         return options
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint(
         "get", raster_renderer.raster_shade_render_get_doc))
-    def get(self, location_name, mapset_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name):
         """Render two raster layers as a composed shade PNG image
         """
         parser = self.create_parser()
@@ -233,7 +229,7 @@ class SyncEphemeralRasterShapeRendererResource(RendererBaseResource):
 
         enqueue_job(
             self.job_timeout, start_shade_job, rdc,
-            queue_type_overwrite=queue_type_overwrite)
+            queue_type_overwrite=True)
 
         http_code, response_model = self.wait_until_finish(0.05)
         if http_code == 200:

--- a/src/actinia_core/rest/raster_renderer.py
+++ b/src/actinia_core/rest/raster_renderer.py
@@ -32,7 +32,8 @@ from actinia_api.swagger2.actinia_core.apidocs import raster_renderer
 
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator
+    endpoint_decorator,
+    check_queue_type_overwrite
 )
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.rest.base.renderer_base import RendererBaseResource
@@ -49,9 +50,10 @@ class SyncEphemeralRasterRendererResource(RendererBaseResource):
     """Render a raster image with g.region/d.rast approach synchronously
     """
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", raster_renderer.raster_render_get_doc))
-    def get(self, location_name, mapset_name, raster_name):
+    def get(self, location_name, mapset_name, raster_name, queue_type_overwrite=None):
         """Render a raster map layer as a PNG image.
         """
         parser = self.create_parser()
@@ -68,7 +70,9 @@ class SyncEphemeralRasterRendererResource(RendererBaseResource):
 
         rdc.set_user_data(options)
 
-        enqueue_job(self.job_timeout, start_job, rdc)
+        enqueue_job(
+            self.job_timeout, start_job, rdc,
+            queue_type_overwrite=queue_type_overwrite)
 
         http_code, response_model = self.wait_until_finish(0.05)
         if http_code == 200:
@@ -119,10 +123,11 @@ class SyncEphemeralRasterRGBRendererResource(RendererBaseResource):
 
         return options
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint(
         "get", raster_renderer.raster_rgb_render_get_doc))
-    def get(self, location_name, mapset_name):
+    def get(self, location_name, mapset_name, queue_type_overwrite=None):
         """Render three raster map layer as composed RGB PNG image.
         """
 
@@ -149,7 +154,9 @@ class SyncEphemeralRasterRGBRendererResource(RendererBaseResource):
 
         rdc.set_user_data(rgb_options)
 
-        enqueue_job(self.job_timeout, start_rgb_job, rdc)
+        enqueue_job(
+            self.job_timeout, start_rgb_job, rdc,
+            queue_type_overwrite=queue_type_overwrite)
 
         http_code, response_model = self.wait_until_finish(0.05)
         if http_code == 200:
@@ -197,10 +204,11 @@ class SyncEphemeralRasterShapeRendererResource(RendererBaseResource):
 
         return options
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint(
         "get", raster_renderer.raster_shade_render_get_doc))
-    def get(self, location_name, mapset_name):
+    def get(self, location_name, mapset_name, queue_type_overwrite=None):
         """Render two raster layers as a composed shade PNG image
         """
         parser = self.create_parser()
@@ -223,7 +231,9 @@ class SyncEphemeralRasterShapeRendererResource(RendererBaseResource):
 
         rdc.set_user_data(options)
 
-        enqueue_job(self.job_timeout, start_shade_job, rdc)
+        enqueue_job(
+            self.job_timeout, start_shade_job, rdc,
+            queue_type_overwrite=queue_type_overwrite)
 
         http_code, response_model = self.wait_until_finish(0.05)
         if http_code == 200:

--- a/src/actinia_core/rest/resource_storage_management.py
+++ b/src/actinia_core/rest/resource_storage_management.py
@@ -42,8 +42,7 @@ from actinia_core.core.common.app import auth
 from actinia_core.core.common.api_logger import log_api_call
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.rest.base.user_auth import check_admin_role
 from actinia_core.rest.base.user_auth import check_user_permissions
@@ -59,35 +58,33 @@ class SyncResourceStorageResource(ResourceBase):
     decorators = [log_api_call, check_user_permissions,
                   check_admin_role, auth.login_required]
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", resource_storage_management.get_doc))
-    def get(self, queue_type_overwrite=None):
+    def get(self):
         """Get the current size of the resource storage"""
         rdc = self.preprocess(has_json=False, has_xml=False)
 
         if rdc:
             enqueue_job(
                 self.job_timeout, start_resource_storage_size, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)
 
         return make_response(jsonify(response_model), http_code)
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint(
         "delete", resource_storage_management.delete_doc))
-    def delete(self, queue_type_overwrite=None):
+    def delete(self):
         """Clean the resource storage and remove all cached data"""
         rdc = self.preprocess(has_json=False, has_xml=False)
 
         if rdc:
             enqueue_job(
                 self.job_timeout, start_resource_storage_remove, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)

--- a/src/actinia_core/rest/resource_storage_management.py
+++ b/src/actinia_core/rest/resource_storage_management.py
@@ -42,7 +42,8 @@ from actinia_core.core.common.app import auth
 from actinia_core.core.common.api_logger import log_api_call
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator
+    endpoint_decorator,
+    check_queue_type_overwrite
 )
 from actinia_core.rest.base.user_auth import check_admin_role
 from actinia_core.rest.base.user_auth import check_user_permissions
@@ -58,29 +59,35 @@ class SyncResourceStorageResource(ResourceBase):
     decorators = [log_api_call, check_user_permissions,
                   check_admin_role, auth.login_required]
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", resource_storage_management.get_doc))
-    def get(self):
+    def get(self, queue_type_overwrite=None):
         """Get the current size of the resource storage"""
         rdc = self.preprocess(has_json=False, has_xml=False)
 
         if rdc:
-            enqueue_job(self.job_timeout, start_resource_storage_size, rdc)
+            enqueue_job(
+                self.job_timeout, start_resource_storage_size, rdc,
+                queue_type_overwrite=queue_type_overwrite)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)
 
         return make_response(jsonify(response_model), http_code)
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint(
         "delete", resource_storage_management.delete_doc))
-    def delete(self):
+    def delete(self, queue_type_overwrite=None):
         """Clean the resource storage and remove all cached data"""
         rdc = self.preprocess(has_json=False, has_xml=False)
 
         if rdc:
-            enqueue_job(self.job_timeout, start_resource_storage_remove, rdc)
+            enqueue_job(
+                self.job_timeout, start_resource_storage_remove, rdc,
+                queue_type_overwrite=queue_type_overwrite)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)

--- a/src/actinia_core/rest/strds_management.py
+++ b/src/actinia_core/rest/strds_management.py
@@ -34,8 +34,7 @@ from actinia_api.swagger2.actinia_core.apidocs import strds_management
 
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.core.request_parser import where_parser
 from actinia_core.rest.base.resource_base import ResourceBase
@@ -54,10 +53,9 @@ class SyncSTRDSListerResource(ResourceBase):
     """
     layer_type = None
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", strds_management.list_get_doc))
-    def get(self, location_name, mapset_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name):
         """Get a list of all STRDS that are located in a specific location/mapset.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -70,7 +68,7 @@ class SyncSTRDSListerResource(ResourceBase):
 
             enqueue_job(
                 self.job_timeout, list_raster_mapsets, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)
@@ -93,10 +91,9 @@ class STRDSManagementResource(ResourceBase):
     """List all STRDS in a location/mapset
     """
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", strds_management.get_doc))
-    def get(self, location_name, mapset_name, strds_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name, strds_name):
         """Get information about a STRDS that is located in a specific location/mapset.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -106,17 +103,16 @@ class STRDSManagementResource(ResourceBase):
         if rdc:
             enqueue_job(
                 self.job_timeout, strds_info, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)
 
         return make_response(jsonify(response_model), http_code)
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("delete", strds_management.delete_doc))
-    def delete(self, location_name, mapset_name, strds_name, queue_type_overwrite=None):
+    def delete(self, location_name, mapset_name, strds_name):
         """Delete a STRDS that is located in a specific location/mapset.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -130,7 +126,7 @@ class STRDSManagementResource(ResourceBase):
 
             enqueue_job(
                 self.job_timeout, strds_delete, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)

--- a/src/actinia_core/rest/strds_raster_management.py
+++ b/src/actinia_core/rest/strds_raster_management.py
@@ -33,8 +33,7 @@ from actinia_api.swagger2.actinia_core.apidocs import strds_raster_management
 
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.core.request_parser import where_parser
@@ -52,10 +51,9 @@ class STRDSRasterManagement(ResourceBase):
     """Manage raster layer in a space time raster dataset
     """
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", strds_raster_management.get_doc))
-    def get(self, location_name, mapset_name, strds_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name, strds_name):
         """Get a list of all raster map layers that are registered in a STRDS
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -69,7 +67,7 @@ class STRDSRasterManagement(ResourceBase):
 
             enqueue_job(
                 self.job_timeout, list_raster_strds, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)
@@ -95,10 +93,9 @@ class STRDSRasterManagement(ResourceBase):
 
         return make_response(jsonify(response_model), http_code)
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("delete", strds_raster_management.delete_doc))
-    def delete(self, location_name, mapset_name, strds_name, queue_type_overwrite=None):
+    def delete(self, location_name, mapset_name, strds_name):
         """Unregister raster map layers from a STRDS located in a specific
         location/mapset.
         """
@@ -110,7 +107,7 @@ class STRDSRasterManagement(ResourceBase):
         if rdc:
             enqueue_job(
                 self.job_timeout, unregister_raster, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish()
         else:
             http_code, response_model = pickle.loads(self.response_data)

--- a/src/actinia_core/rest/strds_renderer.py
+++ b/src/actinia_core/rest/strds_renderer.py
@@ -33,7 +33,8 @@ from actinia_api.swagger2.actinia_core.apidocs import strds_renderer
 
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator
+    endpoint_decorator,
+    check_queue_type_overwrite
 )
 from actinia_core.processing.common.strds_renderer import start_job
 
@@ -45,9 +46,10 @@ __maintainer__ = "mundialis"
 
 class SyncEphemeralSTRDSRendererResource(RendererBaseResource):
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", strds_renderer.get_doc))
-    def get(self, location_name, mapset_name, strds_name):
+    def get(self, location_name, mapset_name, strds_name, queue_type_overwrite=None):
         """Render the raster map layers of a specific STRDS as a single image.
         """
         parser = self.create_parser()
@@ -64,7 +66,9 @@ class SyncEphemeralSTRDSRendererResource(RendererBaseResource):
 
         rdc.set_user_data(options)
 
-        enqueue_job(self.job_timeout, start_job, rdc)
+        enqueue_job(
+            self.job_timeout, start_job, rdc,
+            queue_type_overwrite=queue_type_overwrite)
 
         http_code, response_model = self.wait_until_finish(0.05)
         if http_code == 200:

--- a/src/actinia_core/rest/strds_renderer.py
+++ b/src/actinia_core/rest/strds_renderer.py
@@ -33,8 +33,7 @@ from actinia_api.swagger2.actinia_core.apidocs import strds_renderer
 
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.processing.common.strds_renderer import start_job
 
@@ -46,10 +45,9 @@ __maintainer__ = "mundialis"
 
 class SyncEphemeralSTRDSRendererResource(RendererBaseResource):
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", strds_renderer.get_doc))
-    def get(self, location_name, mapset_name, strds_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name, strds_name):
         """Render the raster map layers of a specific STRDS as a single image.
         """
         parser = self.create_parser()
@@ -68,7 +66,7 @@ class SyncEphemeralSTRDSRendererResource(RendererBaseResource):
 
         enqueue_job(
             self.job_timeout, start_job, rdc,
-            queue_type_overwrite=queue_type_overwrite)
+            queue_type_overwrite=True)
 
         http_code, response_model = self.wait_until_finish(0.05)
         if http_code == 200:

--- a/src/actinia_core/rest/vector_layer.py
+++ b/src/actinia_core/rest/vector_layer.py
@@ -35,7 +35,8 @@ from actinia_api.swagger2.actinia_core.apidocs import vector_layer
 
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator
+    endpoint_decorator,
+    check_queue_type_overwrite
 )
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.core.utils import allowed_file
@@ -54,9 +55,10 @@ class VectorLayerResource(MapLayerRegionResourceBase):
     """Manage a vector map layer
     """
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", vector_layer.get_doc))
-    def get(self, location_name, mapset_name, vector_name):
+    def get(self, location_name, mapset_name, vector_name, queue_type_overwrite=None):
         """Get information about an existing vector map layer.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -65,16 +67,20 @@ class VectorLayerResource(MapLayerRegionResourceBase):
                               map_name=vector_name)
 
         if rdc:
-            enqueue_job(self.job_timeout, start_info_job, rdc)
+            enqueue_job(
+                self.job_timeout, start_info_job, rdc,
+                queue_type_overwrite=queue_type_overwrite)
             http_code, response_model = self.wait_until_finish(0.02)
         else:
             http_code, response_model = pickle.loads(self.response_data)
 
         return make_response(jsonify(response_model), http_code)
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("delete", vector_layer.delete_dop))
-    def delete(self, location_name, mapset_name, vector_name):
+    def delete(
+            self, location_name, mapset_name, vector_name, queue_type_overwrite=None):
         """Delete an existing vector map layer.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -83,7 +89,9 @@ class VectorLayerResource(MapLayerRegionResourceBase):
                               map_name=vector_name)
 
         if rdc:
-            enqueue_job(self.job_timeout, start_delete_job, rdc)
+            enqueue_job(
+                self.job_timeout, start_delete_job, rdc,
+                queue_type_overwrite=queue_type_overwrite)
             http_code, response_model = self.wait_until_finish(0.1)
         else:
             http_code, response_model = pickle.loads(self.response_data)

--- a/src/actinia_core/rest/vector_layer.py
+++ b/src/actinia_core/rest/vector_layer.py
@@ -35,8 +35,7 @@ from actinia_api.swagger2.actinia_core.apidocs import vector_layer
 
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.core.utils import allowed_file
@@ -55,10 +54,9 @@ class VectorLayerResource(MapLayerRegionResourceBase):
     """Manage a vector map layer
     """
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", vector_layer.get_doc))
-    def get(self, location_name, mapset_name, vector_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name, vector_name):
         """Get information about an existing vector map layer.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -69,18 +67,17 @@ class VectorLayerResource(MapLayerRegionResourceBase):
         if rdc:
             enqueue_job(
                 self.job_timeout, start_info_job, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish(0.02)
         else:
             http_code, response_model = pickle.loads(self.response_data)
 
         return make_response(jsonify(response_model), http_code)
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("delete", vector_layer.delete_dop))
     def delete(
-            self, location_name, mapset_name, vector_name, queue_type_overwrite=None):
+            self, location_name, mapset_name, vector_name):
         """Delete an existing vector map layer.
         """
         rdc = self.preprocess(has_json=False, has_xml=False,
@@ -91,7 +88,7 @@ class VectorLayerResource(MapLayerRegionResourceBase):
         if rdc:
             enqueue_job(
                 self.job_timeout, start_delete_job, rdc,
-                queue_type_overwrite=queue_type_overwrite)
+                queue_type_overwrite=True)
             http_code, response_model = self.wait_until_finish(0.1)
         else:
             http_code, response_model = pickle.loads(self.response_data)

--- a/src/actinia_core/rest/vector_renderer.py
+++ b/src/actinia_core/rest/vector_renderer.py
@@ -33,7 +33,8 @@ from actinia_api.swagger2.actinia_core.apidocs import vector_renderer
 
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator
+    endpoint_decorator,
+    check_queue_type_overwrite
 )
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.rest.base.renderer_base import RendererBaseResource
@@ -49,9 +50,10 @@ class SyncEphemeralVectorRendererResource(RendererBaseResource):
     """Render a vector layer with g.region/d.vect approach synchronously
     """
 
+    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", vector_renderer.get_doc))
-    def get(self, location_name, mapset_name, vector_name):
+    def get(self, location_name, mapset_name, vector_name, queue_type_overwrite=None):
         """Render a single vector map layer
         """
         parser = self.create_parser()
@@ -68,7 +70,9 @@ class SyncEphemeralVectorRendererResource(RendererBaseResource):
 
         rdc.set_user_data(options)
 
-        enqueue_job(self.job_timeout, start_job, rdc)
+        enqueue_job(
+            self.job_timeout, start_job, rdc,
+            queue_type_overwrite=queue_type_overwrite)
 
         http_code, response_model = self.wait_until_finish(0.05)
         if http_code == 200:

--- a/src/actinia_core/rest/vector_renderer.py
+++ b/src/actinia_core/rest/vector_renderer.py
@@ -33,8 +33,7 @@ from actinia_api.swagger2.actinia_core.apidocs import vector_renderer
 
 from actinia_core.rest.base.endpoint_config import (
     check_endpoint,
-    endpoint_decorator,
-    check_queue_type_overwrite
+    endpoint_decorator
 )
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.rest.base.renderer_base import RendererBaseResource
@@ -50,10 +49,9 @@ class SyncEphemeralVectorRendererResource(RendererBaseResource):
     """Render a vector layer with g.region/d.vect approach synchronously
     """
 
-    @check_queue_type_overwrite()
     @endpoint_decorator()
     @swagger.doc(check_endpoint("get", vector_renderer.get_doc))
-    def get(self, location_name, mapset_name, vector_name, queue_type_overwrite=None):
+    def get(self, location_name, mapset_name, vector_name):
         """Render a single vector map layer
         """
         parser = self.create_parser()
@@ -72,7 +70,7 @@ class SyncEphemeralVectorRendererResource(RendererBaseResource):
 
         enqueue_job(
             self.job_timeout, start_job, rdc,
-            queue_type_overwrite=queue_type_overwrite)
+            queue_type_overwrite=True)
 
         http_code, response_model = self.wait_until_finish(0.05)
         if http_code == 200:


### PR DESCRIPTION
This PR introduces a decorator for requests which should return an immediate response (HTTP GET and HTTP DELETE) and use the `enqueue_job` method. When the `queue_type` is set to any other than `local`, the request would be pending until the job is worked on which might take a while if a new worker needs to be started.
With the new decorator, the `queue_type` will be overwritten to `local` for these synchronous requests.
A decorator is used so it can be easily enhanced later without touching all the get methods again.