### PR TITLE
docs: replace broken api docs links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,9 +82,8 @@ Note that not all feature requests are accepted.
 
 actinia is in dire need of better documentation. Any contributions of documentation
 are greatly appreciated. The actinia documentation is available on
-[actinia.mundialis.de](https://actinia.mundialis.de/api_docs/).
-The website is generated with [Sphinx](http://www.sphinx-doc.org/en/stable/). Contributions
-to the documentation should be made as [Pull Requests](https://github.com/mundialis/actinia_core/pulls)
+[actinia.mundialis.de](https://actinia.mundialis.de/).
+Contributions to the documentation should be made as [Pull Requests](https://github.com/mundialis/actinia_core/pulls)
 on GitHub.
 
 ## Code contributions

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Sentinel-2 scenes in an ephemeral databases. The computational results of epheme
 are available via object storage as GeoTIFF files.
 
 ## API documentation
+<!---
+a more complete API documentation generated with Spinx was here: https://actinia.mundialis.de/api_docs
+but no longer exists
+--->
 
 The full API documentation is available [here](https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ are available via object storage as GeoTIFF files.
 
 ## API documentation
 
-The full API documentation is available here: https://actinia.mundialis.de/api_docs/
+The full API documentation is available [here](https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json)
 
 ## actinia command execution - actinia shell
 

--- a/docs/docs/actinia_concepts.md
+++ b/docs/docs/actinia_concepts.md
@@ -9,6 +9,10 @@ as swagger[^2]. The JSON definition of the API can be accessed here:
 
  <https://actinia.mundialis.de/latest/swagger.json>
 
+A nicely rendered ReDoc version is available here:
+
+ <https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json>
+
 <!---
 commented out because of 502 Bad Gateway
 The full API documentation is available here:

--- a/docs/docs/actinia_concepts.md
+++ b/docs/docs/actinia_concepts.md
@@ -9,9 +9,12 @@ as swagger[^2]. The JSON definition of the API can be accessed here:
 
  <https://actinia.mundialis.de/latest/swagger.json>
 
+<!---
+commented out because of 502 Bad Gateway
 The full API documentation is available here:
 
  <https://actinia.mundialis.de/api_docs/>
+--->
 
 To generate a readable documentation out of the swagger.json file, the
 spectacle tool can be used:

--- a/docs/docs/actinia_concepts.md
+++ b/docs/docs/actinia_concepts.md
@@ -14,7 +14,7 @@ A nicely rendered ReDoc version is available here:
  <https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json>
 
 <!---
-commented out because of 502 Bad Gateway
+no longer generated:
 The full API documentation is available here:
 
  <https://actinia.mundialis.de/api_docs/>

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -17,7 +17,7 @@ example all Landsat 4-8 scenes as well as all Sentinel-2 scenes in an
 ephemeral databases. The computational results of ephemeral processing
 are available via object storage as GeoTIFF files.
 
-The full API documentation is available here: <https://actinia.mundialis.de/api_docs/>.
+The full API documentation is available here: <https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json>.
 The source code is available here: <https://github.com/mundialis/actinia_core>.
 
 * Introduction

--- a/docs/docs/tutorial_landsat_ndvi.md
+++ b/docs/docs/tutorial_landsat_ndvi.md
@@ -4,7 +4,7 @@ Landsat NDVI computation
 Actinia provides several API calls to compute satellite specific
 parameters:
 
- <https://actinia.mundialis.de/api_docs/#tag-Satellite-Image-Algorithms>
+ <https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json#tag-Satellite-Image-Algorithms>
 
  We will use the Unix shell and curl to access the REST API. First open a shell of choice (we use bash here) and setup the login information, the  IP address and the port on which the actinia service is running, so you can simply change the IP and port if your server uses a different
  address:

--- a/docs/docs/tutorial_process_chain.md
+++ b/docs/docs/tutorial_process_chain.md
@@ -23,13 +23,13 @@ that is used as computational environment.
 A process chain is a list of GRASS GIS modules[^1] that will be executed in
 serial, based on the order of the list. GRASS GIS modules are specified
 as process definitions[^2] that include the name of the command, the
-inputs[^3] and outputs[^4], including import and export definitions as
+inputs and outputs], including import and export definitions as
 well as the module flags.
 
 The following example defines a single process
-that runs the GRASS GIS module *r.slope.aspect*[^5] to compute the
+that runs the GRASS GIS module *r.slope.aspect*[^3] to compute the
 *slope* for the raster map layer *elev\_ned\_30m* that is located in the
-mapset[^6] *PERMANENT*. The output of the module is named
+mapset[^4] *PERMANENT*. The output of the module is named
 *elev\_ned\_30m\_slope* and should be exported as a GeoTiff file.
 
 ```json
@@ -62,7 +62,7 @@ The actinia process chain supports the specification of URL\'s to raster
 layers in the input definition. The following process chain imports a
 raster map layer that is located in an object storage with the name
 *elev\_ned\_30m\_new* and sets the computational region for the
-following processing step with the GRASS GIS module *g.region*[^7]. Then
+following processing step with the GRASS GIS module *g.region*[^5]. Then
 slope and aspect are computed with *r.slope.aspect* and specified for
 export as GeoTiff files.
 
@@ -1361,14 +1361,14 @@ The finished response should look like this:
 [^2]: <https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json#tag/Module-Viewer/paths/~1grass_modules/get>
 
 <!---
-for 3 and 4, use https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json#tag/Processing ?
+https://actinia.mundialis.de/api_docs/ is no longer generated
+
+[^x]: <https://actinia.mundialis.de/api_docs/#/definitions/InputParameter>
+
+[^x]: <https://actinia.mundialis.de/api_docs/#/definitions/OutputParameter>
 --->
-[^3]: <https://actinia.mundialis.de/api_docs/#/definitions/InputParameter>
+[^3]: <https://grass.osgeo.org/grass-stable/manuals/r.slope.aspect.html>
 
-[^4]: <https://actinia.mundialis.de/api_docs/#/definitions/OutputParameter>
+[^4]: <https://grass.osgeo.org/grass-stable/manuals/grass_database.html>
 
-[^5]: <https://grass.osgeo.org/grass-stable/manuals/r.slope.aspect.html>
-
-[^6]: <https://grass.osgeo.org/grass-stable/manuals/grass_database.html>
-
-[^7]: <https://grass.osgeo.org/grass-stable/manuals/g.region.html>
+[^5]: <https://grass.osgeo.org/grass-stable/manuals/g.region.html>

--- a/docs/docs/tutorial_process_chain.md
+++ b/docs/docs/tutorial_process_chain.md
@@ -1358,8 +1358,11 @@ The finished response should look like this:
 
 [^1]: <https://grass.osgeo.org/grass-stable/manuals/index.html>
 
-[^2]: <https://actinia.mundialis.de/api_docs/#/definitions/GrassModule>
+[^2]: <https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json#tag/Module-Viewer/paths/~1grass_modules/get>
 
+<!---
+for 3 and 4, use https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json#tag/Processing ?
+--->
 [^3]: <https://actinia.mundialis.de/api_docs/#/definitions/InputParameter>
 
 [^4]: <https://actinia.mundialis.de/api_docs/#/definitions/OutputParameter>

--- a/src/actinia_core/core/common/app.py
+++ b/src/actinia_core/core/common/app.py
@@ -45,7 +45,7 @@ time series data located in a persistent GRASS GIS database.
 Sentinel2A scenes in an ephemeral databases. The computational results of ephemeral processing
 are available via object storage as GeoTIFF files.
 
-The full API documentation is available here: https://actinia.mundialis.de/api_docs/
+The full API documentation is available here: https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json
 
 
 Examples:


### PR DESCRIPTION
Fixes https://github.com/mundialis/actinia-jupyter/issues/8

TODO: links like [https://actinia.mundialis.de/api_docs/#/definitions/](https://actinia.mundialis.de/api_docs/#/definitions/) do not have an equivalent in [https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json](https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json) ?