### PR TITLE
Allow separate config for worker

### DIFF
--- a/src/actinia_core/processing/actinia_processing/ephemeral_processing.py
+++ b/src/actinia_core/processing/actinia_processing/ephemeral_processing.py
@@ -40,6 +40,7 @@ import uuid
 from flask import json
 from requests.auth import HTTPBasicAuth
 
+from actinia_core.core.common.config import global_config, DEFAULT_CONFIG_PATH
 from actinia_core.core.common.process_object import Process
 from actinia_core.core.grass_init import GrassInitializer
 from actinia_core.core.messages_logger import MessageLogger
@@ -126,7 +127,11 @@ class EphemeralProcessing(object):
         # rdc = ResourceDataContainer()
 
         self.rdc = rdc
-        self.config = self.rdc.config
+        if os.path.exists(DEFAULT_CONFIG_PATH) is True and os.path.isfile(DEFAULT_CONFIG_PATH):
+            self.config = global_config.read(DEFAULT_CONFIG_PATH)
+        else:
+            self.config = self.rdc.config
+
         self.data = self.rdc.user_data
         self.grass_temp_database = self.config.GRASS_TMP_DATABASE
 


### PR DESCRIPTION
Currently, the processing part in actinia reads the config from the process queue in redis (when configured) via the `resource data container` object. This means that the config is used which is meant for the actinia which receives the job and writes it into the queue.
The worker config can only be specified for

- REDIS_QUEUE_SERVER_URL
- REDIS_QUEUE_SERVER_PORT
- REDIS_QUEUE_SERVER_PASSWORD
- LOG_INTERFACE
- LOG_FLUENT_HOST
- LOG_FLUENT_PORT
- WORKER_LOGFILE

But many other config is not read from the worker config, e.g. additional redis config (for users etc), data mounts, ... which obviously can differ between the actinia instance receiving the job and the actinia worker.

This PR fixes this.
Anything I might oversee @anikaweinmann @metzm ?