### PR TITLE
joblib_1_1_0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ google-cloud>=0.32.0
 google-cloud-bigquery<=3.0.0
 google-cloud-storage>=1.6.0
 gunicorn>=19.9.0
-joblib==0.15.1
+joblib==1.1.0
 MarkupSafe==2.0.1 # TODO: remove when #345 is fixed
 matplotlib==3.3.4
 passlib>=1.7.1


### PR DESCRIPTION
This PR updates the python joblib library to 1.1.0 as it may otherwise lead to errors when multiprocessing in scikit-learn:
```
--------------------------------------------------------------------------------
LokyProcess-7 failed with traceback:
--------------------------------------------------------------------------------
Traceback (most recent call last):
File "/usr/lib/python3.9/site-packages/joblib/externals/loky/backend/popen_loky_posix.py", line 199, in <module>
process_obj = pickle.load(from_parent)
File "/usr/lib/python3.9/site-packages/joblib/externals/loky/backend/queues.py", line 75, in _setstate_
self._after_fork()
File "/usr/lib/python3.9/multiprocessing/queues.py", line 69, in _after_fork
self._reset(after_fork=True)
File "/usr/lib/python3.9/multiprocessing/queues.py", line 73, in _reset
self._notempty._at_fork_reinit()
AttributeError: '_SafeQueue' object has no attribute '_notempty'
```