### PR TITLE
Fix redoc rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ a more complete API documentation generated with Spinx was here: https://actinia
 but no longer exists
 --->
 
-The full API documentation is available [here](https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json)
+The full API documentation is available [here](https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json&nocors)
 
 ## actinia command execution - actinia shell
 


### PR DESCRIPTION
The API docs give only an error currently. Adding `&nocors` aparently helps. (maybe browser dependent?)
See: https://github.com/Redocly/redoc/issues/2009 for background
Should probably be changed other places as well. I can have a look at it if the issue is not only occurring om my browser...