### PR TITLE
replace deprecated (Timed)JSONWebSignatureSerializer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ wheel
 geopandas
 rasterio==1.2.10
 pystac==0.5.6
+jwt
 # required for running i.sentinel.download from GCS:
 pandas
 sentinelsat

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ wheel
 geopandas
 rasterio==1.2.10
 pystac==0.5.6
-jwt
+PyJWT
 # required for running i.sentinel.download from GCS:
 pandas
 sentinelsat

--- a/src/actinia_core/core/common/user.py
+++ b/src/actinia_core/core/common/user.py
@@ -674,8 +674,7 @@ class ActiniaUser(object):
                 global_config.SECRET_KEY,
                 leeway=timedelta(seconds=10),
                 algorithms=["HS512"],
-                options={"require": ["exp"],
-                         "verify_exp": "verify_signature"},
+                options={"require": ["exp"], "verify_exp": "verify_signature"},
             )
         except jwt.exceptions.DecodeError:
             return None

--- a/src/actinia_core/core/common/user.py
+++ b/src/actinia_core/core/common/user.py
@@ -645,12 +645,16 @@ class ActiniaUser(object):
             Actinia Core_api.common.user.ActiniaUser:
             A user object is success or None
         """
-        data = jwt.decode(
-            api_key,
-            global_config.SECRET_KEY,
-            leeway=timedelta(seconds=10),
-            algorithms=["HS512"],
-        )
+        try:
+            data = jwt.decode(
+                api_key,
+                global_config.SECRET_KEY,
+                leeway=timedelta(seconds=10),
+                algorithms=["HS512"],
+            )
+        except jwt.exceptions.DecodeError:
+            return None
+
         if data is None:
             return None
         if "user_id" not in data.keys():
@@ -664,12 +668,15 @@ class ActiniaUser(object):
 
     @staticmethod
     def verify_auth_token(token):
-        data = jwt.decode(
-            token,
-            global_config.SECRET_KEY,
-            leeway=timedelta(seconds=10),
-            algorithms=["HS512"],
-        )
+        try:
+            data = jwt.decode(
+                token,
+                global_config.SECRET_KEY,
+                leeway=timedelta(seconds=10),
+                algorithms=["HS512"],
+            )
+        except jwt.exceptions.DecodeError:
+            return None
 
         if data is None:
             return None

--- a/src/actinia_core/core/common/user.py
+++ b/src/actinia_core/core/common/user.py
@@ -674,7 +674,7 @@ class ActiniaUser(object):
                 global_config.SECRET_KEY,
                 leeway=timedelta(seconds=10),
                 algorithms=["HS512"],
-                options={"require": ["exp"], "verify_exp": "verify_signature"},
+                options={"require": ["exp"], "verify_exp": True},
             )
         except jwt.exceptions.DecodeError:
             return None

--- a/src/actinia_core/rest/user_api_key.py
+++ b/src/actinia_core/rest/user_api_key.py
@@ -81,7 +81,7 @@ class APIKeyCreationResource(LoginBase):
                 jsonify(
                     TokenResponseModel(
                         status="success",
-                        token=g.user.generate_api_key().decode(),
+                        token=g.user.generate_api_key(),
                         message="API key successfully generated",
                     )
                 )
@@ -131,7 +131,7 @@ class TokenCreationResource(LoginBase):
                         status="success",
                         token=g.user.generate_auth_token(
                             expiration=expiration
-                        ).decode(),
+                        ),
                         message="Token successfully generated with "
                         "an expiration time of %i seconds" % expiration,
                     )


### PR DESCRIPTION
Fixes #345 

This PR proposes to use jwt instead of itsdangerous to 1) no longer use a deprecated component, 2) solve python lib conflicts with the actinia-stac plugin.
(Timed)JSONWebSignatureSerializer uses by default HS512 as hash algorithm, therefore this PR also uses this algorithm with jwt, in the hope that existing API keys are still recognized as valid keys.