### PR TITLE
Improve interim results by include additional mapsets

### DIFF
--- a/job_resumption.md
+++ b/job_resumption.md
@@ -55,6 +55,20 @@ The interim results will be deleted automatically if a job resource is successfu
 - Startup actinia with above config in preferred way, e.g.
 `cd ~/repos/actinia` + press F5
 
+## Additional mapsets
+For parallelization on different region some GRASS GIS could create additional
+mapsets and use the data from these mapsets in further calculations without
+copying them to the temporary mapsets. To add the possibility to also resumpt
+jobs where such addional mapsets are created in a previous step you can
+configure additional mapsets which should be included in the interim results
+by setting a pattern for the mapset name, e.g.:
+```
+[MISC]
+save_interim_results = onError
+save_interim_results_endpoints_cfg = /etc/default/actinia_interim_endpoints.csv
+include_additional_mapset_pattern = test_tmp_*
+```
+
 
 ## Job resumption examples
 ```

--- a/src/actinia_core/core/common/config.py
+++ b/src/actinia_core/core/common/config.py
@@ -425,6 +425,7 @@ class Configuration(object):
             "AsyncEphemeralExportResource".lower(): "AsyncEphemeralExportResource",
             "AsyncPersistentResource".lower(): "AsyncPersistentResource",
         }
+        self.INCLUDE_ADDITIONAL_MAPSET_PATTERN = None
 
         """
         LOGGING
@@ -648,6 +649,11 @@ class Configuration(object):
             "MISC",
             "INTERIM_SAVING_ENDPOINTS",
             str(self.INTERIM_SAVING_ENDPOINTS),
+        )
+        config.set(
+            "MISC",
+            "INCLUDE_ADDITIONAL_MAPSET_PATTERN",
+            str(self.INCLUDE_ADDITIONAL_MAPSET_PATTERN),
         )
 
         config.add_section("LOGGING")
@@ -913,6 +919,12 @@ class Configuration(object):
                             self.INTERIM_SAVING_ENDPOINTS.update(
                                 endpoints_dict
                             )
+                if config.has_option(
+                    "MISC", "INCLUDE_ADDITIONAL_MAPSET_PATTERN"
+                ):
+                    self.INCLUDE_ADDITIONAL_MAPSET_PATTERN = config.get(
+                        "MISC", "INCLUDE_ADDITIONAL_MAPSET_PATTERN"
+                    )
 
             if config.has_section("LOGGING"):
                 if config.has_option("LOGGING", "LOG_INTERFACE"):

--- a/src/actinia_core/core/interim_results.py
+++ b/src/actinia_core/core/interim_results.py
@@ -84,8 +84,9 @@ class InterimResult(object):
         self.iteration = iteration if iteration is not None else 1
         self.old_pc_step = None
         self.endpoint = endpoint
-        self.include_additional_mapset_pattern = \
+        self.include_additional_mapset_pattern = (
             global_config.INCLUDE_ADDITIONAL_MAPSET_PATTERN
+        )
 
     def set_old_pc_step(self, old_pc_step):
         """Set method for the number of the successfully finished steps of
@@ -208,7 +209,9 @@ class InterimResult(object):
                              mapset should be saved
         """
 
-        src_path = f"{self._get_interim_mapset_path(self.old_pc_step)}_add_mapsets"
+        src_path = (
+            f"{self._get_interim_mapset_path(self.old_pc_step)}_add_mapsets"
+        )
         if not os.path.isdir(src_path):
             return
 
@@ -303,7 +306,7 @@ class InterimResult(object):
         )
 
     def _get_included_additional_mapset_pathes(
-            self, temp_mapset_path, progress_step
+        self, temp_mapset_path, progress_step
     ):
         """Returns lists with source pathes of hte additional mapsets and
         destination pathes for them"""
@@ -311,7 +314,9 @@ class InterimResult(object):
         if self.include_additional_mapset_pattern:
             pattern = self.include_additional_mapset_pattern
             tmp_path = os.path.dirname(temp_mapset_path)
-            dest_path = f"{self._get_interim_mapset_path(progress_step)}_add_mapsets"
+            dest_path = (
+                f"{self._get_interim_mapset_path(progress_step)}_add_mapsets"
+            )
             mapsets = filter(os.listdir(tmp_path), pattern)
             srcs = [os.path.join(tmp_path, mapset) for mapset in mapsets]
             dests = [os.path.join(dest_path, mapset) for mapset in mapsets]
@@ -381,9 +386,7 @@ class InterimResult(object):
             )
             # saving additional mapsets
             _, old_dests = self._get_included_additional_mapset_pathes(
-                temp_mapset_path, progress_step -1
+                temp_mapset_path, progress_step - 1
             )
             for m_src, m_dest, old_dest in zip(addm_src, addm_dest, old_dests):
-                self._saving_folder(
-                    m_src, m_dest, old_dest, progress_step
-                )
+                self._saving_folder(m_src, m_dest, old_dest, progress_step)

--- a/src/actinia_core/processing/actinia_processing/ephemeral_processing.py
+++ b/src/actinia_core/processing/actinia_processing/ephemeral_processing.py
@@ -1114,6 +1114,8 @@ class EphemeralProcessing(object):
                     "Error while rsyncing of interim results to new temporare "
                     "mapset"
                 )
+            self.interim_result.rsync_addidtional_mapsets(
+                os.path.dirname(self.temp_mapset_path))
         if interim_result_file_path:
             self.message_logger.info(
                 "Rsync interim result file path to temporary GRASS DB"

--- a/src/actinia_core/processing/actinia_processing/ephemeral_processing.py
+++ b/src/actinia_core/processing/actinia_processing/ephemeral_processing.py
@@ -1115,7 +1115,8 @@ class EphemeralProcessing(object):
                     "mapset"
                 )
             self.interim_result.rsync_addidtional_mapsets(
-                os.path.dirname(self.temp_mapset_path))
+                os.path.dirname(self.temp_mapset_path)
+            )
         if interim_result_file_path:
             self.message_logger.info(
                 "Rsync interim result file path to temporary GRASS DB"


### PR DESCRIPTION
Add possibility to configure pattern to save addional mapsets in the interim resutls.
For parallelization on different region some GRASS GIS could create additional mapsets and use the data from these mapsets in further calculations without copying them to the temporary mapsets. To add the possibility to also resumpt jobs where such addional mapsets are created in a previous step you can configure additional mapsets which should be included in the interim results by setting a pattern for the mapset name, e.g.:
```
[MISC]
save_interim_results = onError
save_interim_results_endpoints_cfg = /etc/default/actinia_interim_endpoints.csv
include_additional_mapset_pattern = test_tmp_*
```