### PR TITLE
Adjust stdin for Parameters

### DIFF
--- a/src/actinia_core/core/common/process_chain.py
+++ b/src/actinia_core/core/common/process_chain.py
@@ -64,7 +64,7 @@ __email__ = "info@mundialis.de"
 
 def get_param_stdin_part(text):
     """Function to get method and filter from parameter value"""
-    for delimiter in ["::", " ", "+", "-", "*", ":", "(", ")"]:
+    for delimiter in ["::", " ", "+", "-", "*", ":", "(", ")", ","]:
         text = text.split(delimiter, 1)[0]
     return text
 
@@ -1269,10 +1269,7 @@ class ProcessChainConverter(object):
                         self.generate_temp_file_path()
                     )
                 param = "%s=%s" % (param, self.temporary_pc_files[file_id])
-            elif "::" in value and value.split("::")[1] in [
-                "stdout",
-                "stderr",
-            ]:
+            elif "::stdout" in value or "::stderr" in value:
                 param_val = self._create_param_stdin_process(
                     param_stdin_funcs, value, param
                 )


### PR DESCRIPTION
Adjustments of stdin for parameters support from here https://github.com/actinia-org/actinia-core/pull/501

* adjust filtering of `stdout::`/`stderr::`: needed e.g. when called multiple times (and not having second `::` separator as e.g. `get_stats::stdout::min`) . Example
   ``` 
        {
            "id": "calc_b04",
            "module": "r.mapcalc",
            "inputs": [
                {
                    "param": "expression",
                    "value": "test_b04 = g_list_raster_b04::stdout + g_list_raster_b04::stdout"
                }
            ]
        }
  ```
* add comma as delimiter. Needed for example for:
   ```
        {
            "id": "rename_b04",
            "module": "g.rename",
            "inputs": [
                {
                    "param": "raster",
                    "value": "g_list_raster_b04::stdout,B04"
                }
            ]
        },
   ```