### PR TITLE
Update alpine and grass version in Dockerfile

### DIFF
--- a/docker/actinia-core-alpine/Dockerfile
+++ b/docker/actinia-core-alpine/Dockerfile
@@ -19,7 +19,11 @@ ENV GISBASE ""
 COPY --from=grass /usr/local/bin/grass /usr/local/bin/grass
 COPY --from=grass /usr/local/grass* /usr/local/grass/
 
-RUN apk add parallel && \
+# DL4006: Set the SHELL option -o pipefail before RUN with a pipe in it -
+# can be ignored for alpine as pipe fails on error
+# DL3018: Pin versions in apk add
+# hadolint ignore=DL3018,DL4006
+RUN apk add --no-cache parallel && \
    find /usr/local/ -type f -print0 | parallel -0 'file {}' \; | \
    grep ":.* ASCII text" | cut -d: -f1 | \
    xargs sed -i "s+/grass8.+/grass+g" && \


### PR DESCRIPTION
Duplicate of #678

This PR updates the alpine based Dockerimage
- from `alpine:3.21` to `alpine:3.23`
- from GRASS GIS `releasebranch_8_4` to `main`

The cryptic-looking code below (developed with @neteler) was introduced because otherwise the following error occured:

```
Step 11/36 : COPY --from=grass /usr/local/bin/grass /usr/local/bin/grass
 ---> Using cache
 ---> 77c69f7b36df
Step 12/36 : COPY --from=grass /usr/local/grass* /usr/local/grass/
 ---> Using cache
 ---> f7291cb29074
Step 13/36 : RUN ln -s /usr/local/grass "$(grass --config path)"
 ---> Running in d75b766bbb98
Traceback (most recent call last):
  File "/usr/local/bin/grass", line 2524, in <module>
    main()
  File "/usr/local/bin/grass", line 2165, in main
    find_grass_python_package()
  File "/usr/local/bin/grass", line 2114, in find_grass_python_package
    raise RuntimeError(msg)
RuntimeError: /usr/local/grass85/etc/python with the grass Python package does not exist. Is the installation of GRASS complete?
ln: failed to create symbolic link '': No such file or directory
The command '/bin/sh -c ln -s /usr/local/grass "$(grass --config path)"' returned a non-zero code: 1
```