### PR TITLE
Enable footnotes in MkDocs documentation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -27,6 +27,9 @@ theme:     readthedocs
 # https://github.com/mkdocs/mkdocs/issues/991
 use_directory_urls: true
 extra_css: [extra.css]
+
+markdown_extensions:
+  - footnotes
 nav:
   - Home: 'index.md'
   - Introduction: 'introduction.md'


### PR DESCRIPTION
This PR enables the `footnotes` Markdown extension in the MkDocs configuration.

I tested it locally with `mkdocs serve`, and the Footnotes section is now rendered correctly.

Related to #305.