### PR TITLE
Update actinia API URLs in documentation

### DIFF
--- a/docs/docs/actinia_concepts.md
+++ b/docs/docs/actinia_concepts.md
@@ -5,11 +5,11 @@
 Actinia is fully documented using the OpenAPI standard[^1], better known
 as swagger[^2]. The JSON definition of the API can be accessed here:
 
-<https://actinia.mundialis.de/latest/swagger.json>
+<https://actinia.mundialis.de/api/v3/swagger.json>
 
 A nicely rendered ReDoc version is available here:
 
-<https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json>
+<https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/api/v3/swagger.json>
 
 <!---
 no longer generated:
@@ -23,7 +23,7 @@ spectacle tool can be used:
 
 ```bash
  # Download the latest swagger definition from the actinia service
- wget  https://actinia.mundialis.de/latest/swagger.json -O /tmp/actinia.json
+ wget  https://actinia.mundialis.de/api/v3/swagger.json -O /tmp/actinia.json
 
  # Run spectacle docker image to generate the HTML documentation
  docker run -v /tmp:/tmp -t sourcey/spectacle spectacle /tmp/actinia.json -t /tmp

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -25,24 +25,24 @@ example all Landsat 4-8 scenes as well as all Sentinel-2 scenes in an
 ephemeral databases. The computational results of ephemeral processing
 are available via object storage as GeoTIFF files.
 
-The full API documentation is available here: <https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json>.
+The full API documentation is available here: <https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/api/v3/swagger.json>.
 The source code is available here: <https://github.com/actinia-org/actinia-core>.
 
 - Introduction
-  - What is REST?
-  - Examples
+    - What is REST?
+    - Examples
 - Actinia concepts
-  - Actinia REST API documentation
-  - User, user-roles and user-groups
-  - The Actinia databases
+    - Actinia REST API documentation
+    - User, user-roles and user-groups
+    - The Actinia databases
 - Installation
 - Actinia database access
-  - Using curl for HTTP requests
-  - Access to projects and mapsets in the persistent database
-  - Access to raster layers in the persistent database
-  - Access to raster time-series in the persistent database
+    - Using curl for HTTP requests
+    - Access to projects and mapsets in the persistent database
+    - Access to raster layers in the persistent database
+    - Access to raster time-series in the persistent database
 - Time-series sampling
-  - Sampling of a STRDS with vector points
+    - Sampling of a STRDS with vector points
 
 <!---
 * Landsat NDVI computation
@@ -50,7 +50,7 @@ The source code is available here: <https://github.com/actinia-org/actinia-core>
 -->
 
 - User defined processing
-  - The actinia process chain
-  - Sentinel-2A NDVI process chain
+    - The actinia process chain
+    - Sentinel-2A NDVI process chain
 - License
 - Authors

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,20 +29,20 @@ The full API documentation is available here: <https://redocly.github.io/redoc/?
 The source code is available here: <https://github.com/actinia-org/actinia-core>.
 
 - Introduction
-    - What is REST?
-    - Examples
+  - What is REST?
+  - Examples
 - Actinia concepts
-    - Actinia REST API documentation
-    - User, user-roles and user-groups
-    - The Actinia databases
+  - Actinia REST API documentation
+  - User, user-roles and user-groups
+  - The Actinia databases
 - Installation
 - Actinia database access
-    - Using curl for HTTP requests
-    - Access to projects and mapsets in the persistent database
-    - Access to raster layers in the persistent database
-    - Access to raster time-series in the persistent database
+  - Using curl for HTTP requests
+  - Access to projects and mapsets in the persistent database
+  - Access to raster layers in the persistent database
+  - Access to raster time-series in the persistent database
 - Time-series sampling
-    - Sampling of a STRDS with vector points
+  - Sampling of a STRDS with vector points
 
 <!---
 * Landsat NDVI computation
@@ -50,7 +50,7 @@ The source code is available here: <https://github.com/actinia-org/actinia-core>
 -->
 
 - User defined processing
-    - The actinia process chain
-    - Sentinel-2A NDVI process chain
+  - The actinia process chain
+  - Sentinel-2A NDVI process chain
 - License
 - Authors

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -41,7 +41,7 @@ can simply change the IP and port if your server uses a different
 address:
 
 ```bash
-export ACTINIA_URL=https://actinia.mundialis.de/latest
+export ACTINIA_URL=https://actinia.mundialis.de/api/v3
 export AUTH='-u demouser:gu3st!pa55w0rd'
 # other user credentials can be provided in the same way
 ```

--- a/docs/docs/tutorial_landsat_ndvi.md
+++ b/docs/docs/tutorial_landsat_ndvi.md
@@ -3,13 +3,13 @@
 Actinia provides several API calls to compute satellite specific
 parameters:
 
-<https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json#tag-Satellite-Image-Algorithms>
+<https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/api/v3/swagger.json#tag-Satellite-Image-Algorithms>
 
 We will use the Unix shell and curl to access the REST API. First open a shell of choice (we use bash here) and setup the login information, the  IP address and the port on which the actinia service is running, so you can simply change the IP and port if your server uses a different
 address:
 
 ```bash
-export ACTINIA_URL=https://actinia.mundialis.de/latest
+export ACTINIA_URL=https://actinia.mundialis.de/api/v3
 export AUTH='-u demouser:gu3st!pa55w0rd'
 # other user credentials can be provided in the same way
 ```
@@ -62,7 +62,7 @@ URL. Be aware that you have to use your status url as the resource id will chang
 calls.
 
 ```bash
- curl -L ${AUTH} -X GET "https://actinia.mundialis.de/api/v3/resources/demouser/resource_id-a12d80c1-539a-45b9-a78c-ee4014f50d03"
+ curl -L ${AUTH} -X GET "${ACTINIA_URL}/resources/demouser/resource_id-a12d80c1-539a-45b9-a78c-ee4014f50d03"
 ```
 
 The final result will contain a complete processing list as well as

--- a/docs/docs/tutorial_process_chain.md
+++ b/docs/docs/tutorial_process_chain.md
@@ -602,7 +602,7 @@ We will use the Unix shell and curl to access the REST API. First open a shell o
 address:
 
 ```bash
-export ACTINIA_URL=https://actinia.mundialis.de/latest
+export ACTINIA_URL=https://actinia.mundialis.de/api/v3
 export AUTH='-u demouser:gu3st!pa55w0rd'
 # other user credentials can be provided in the same way
 ```
@@ -1031,7 +1031,7 @@ https://actinia.mundialis.de/api_docs/ is no longer generated
 --->
 
 [^1]: https://grass.osgeo.org/grass-stable/manuals/index.html
-[^2]: https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/latest/swagger.json#tag/Module-Viewer/paths/~1grass_modules/get
+[^2]: https://redocly.github.io/redoc/?url=https://actinia.mundialis.de/api/v3/swagger.json#tag/Module-Viewer/paths/~1grass_modules/get
 [^3]: https://grass.osgeo.org/grass-stable/manuals/r.slope.aspect.html
 [^4]: https://grass.osgeo.org/grass-stable/manuals/grass_database.html
 [^5]: https://grass.osgeo.org/grass-stable/manuals/g.region.html

--- a/docs/docs/tutorial_sentinel2_ndvi.md
+++ b/docs/docs/tutorial_sentinel2_ndvi.md
@@ -4,7 +4,7 @@ We will use the Unix shell and curl to access the REST API. First open a shell o
 address:
 
 ```bash
-export ACTINIA_URL=https://actinia.mundialis.de/latest
+export ACTINIA_URL=https://actinia.mundialis.de/api/v3
 export AUTH='-u demouser:gu3st!pa55w0rd'
 # other user credentials can be provided in the same way
 ```
@@ -51,7 +51,7 @@ Poll the status of the asynchronous API call by polling the status URL.
 Be aware that you have to change the status url as the resource id will change for different NDVI API calls.
 
 ```bash
- curl ${AUTH} -X GET http://actinia.mundialis.de/api/v3/resources/demouser/resource_id-6b849585-576f-40b5-a514-34a7cf1f97ce
+ curl ${AUTH} -X GET "${ACTINIA_URL}/resources/demouser/resource_id-6b849585-576f-40b5-a514-34a7cf1f97ce"
 ```
 
 The final result will contain a complete processing list as well as

--- a/docs/docs/tutorial_strds_sampling.md
+++ b/docs/docs/tutorial_strds_sampling.md
@@ -11,7 +11,7 @@ We will use the Unix shell and curl to access the REST API. First open a shell o
 address:
 
 ```bash
-export ACTINIA_URL=https://actinia.mundialis.de/latest
+export ACTINIA_URL=https://actinia.mundialis.de/api/v3
 export AUTH='-u demouser:gu3st!pa55w0rd'
 # other user credentials can be provided in the same way
 ```


### PR DESCRIPTION
This PR updates outdated actinia API URLs in multiple Markdown documentation files.

The documentation previously used:

- https://actinia.mundialis.de/latest
- https://actinia.mundialis.de/latest/swagger.json

These have been replaced with:

- https://actinia.mundialis.de/api/v3
- https://actinia.mundialis.de/api/v3/swagger.json