### PR TITLE
remove setuptools from requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "actinia-core"
-version = "7.1.1"
+version = "7.1.2"
 description = "Actinia Core is an open source REST API for scalable, distributed, high performance processing of geographical data that uses mainly GRASS GIS for computational tasks"
 readme = "README.md"
 authors = [
@@ -59,7 +59,6 @@ dependencies = [
     "python-magic>=0.4.15",
     "requests>=2.20.0",
     "rq==1.16.2",
-    "setuptools==82.0.1",
     "geopandas",
     "rasterio==1.5.0",
     "pystac==1.14.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "actinia-core"
-version = "7.1.2"
+version = "7.1.1"
 description = "Actinia Core is an open source REST API for scalable, distributed, high performance processing of geographical data that uses mainly GRASS GIS for computational tasks"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
setuptools is (at least should not be) not a runtime dependency, however with a specific version pinned, it causes a version conflict with actinia-grassdata-management-plugin==1.0.0
Therefore I suggest to remove it from dependencies (also from other plugins).